### PR TITLE
[feat] 엔티티 클래스 생성

### DIFF
--- a/src/main/java/pie/tomato/tomatomarket/domain/Category.java
+++ b/src/main/java/pie/tomato/tomatomarket/domain/Category.java
@@ -1,0 +1,21 @@
+package pie.tomato.tomatomarket.domain;
+
+import static javax.persistence.GenerationType.*;
+import static lombok.AccessLevel.*;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+public class Category {
+
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	private Long id;
+	private String name;
+	private String categoryImage;
+}

--- a/src/main/java/pie/tomato/tomatomarket/domain/ChatLog.java
+++ b/src/main/java/pie/tomato/tomatomarket/domain/ChatLog.java
@@ -1,0 +1,34 @@
+package pie.tomato.tomatomarket.domain;
+
+import static javax.persistence.FetchType.*;
+import static javax.persistence.GenerationType.*;
+import static lombok.AccessLevel.*;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+public class ChatLog {
+
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	private Long id;
+	private String message;
+	private String to;
+	private String from;
+	private LocalDateTime createdAt;
+	private Long newMessage;
+
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(name = "chatroom_id")
+	private Chatroom chatroom;
+
+}

--- a/src/main/java/pie/tomato/tomatomarket/domain/Chatroom.java
+++ b/src/main/java/pie/tomato/tomatomarket/domain/Chatroom.java
@@ -1,0 +1,34 @@
+package pie.tomato.tomatomarket.domain;
+
+import static javax.persistence.FetchType.*;
+import static javax.persistence.GenerationType.*;
+import static lombok.AccessLevel.*;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+public class Chatroom {
+
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	private Long id;
+	private LocalDateTime createdAt;
+
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
+
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(name = "item_id")
+	private Item item;
+
+}

--- a/src/main/java/pie/tomato/tomatomarket/domain/Image.java
+++ b/src/main/java/pie/tomato/tomatomarket/domain/Image.java
@@ -1,0 +1,28 @@
+package pie.tomato.tomatomarket.domain;
+
+import static javax.persistence.FetchType.*;
+import static javax.persistence.GenerationType.*;
+import static lombok.AccessLevel.*;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+public class Image {
+
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	private Long id;
+	private String imageUrl;
+	private boolean thumbnail;
+
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(name = "item_id")
+	private Item item;
+}

--- a/src/main/java/pie/tomato/tomatomarket/domain/Item.java
+++ b/src/main/java/pie/tomato/tomatomarket/domain/Item.java
@@ -1,0 +1,42 @@
+package pie.tomato.tomatomarket.domain;
+
+import static javax.persistence.FetchType.*;
+import static javax.persistence.GenerationType.*;
+import static lombok.AccessLevel.*;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+public class Item {
+
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	private Long id;
+	private String title;
+	private String content;
+	private Long price;
+	private String thumbnail;
+	private String status;
+	private String region;
+	private Long chatCount;
+	private Long wishCount;
+	private Long viewCount;
+	private LocalDateTime createdAt;
+
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
+
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(name = "category_id")
+	private Category category;
+}

--- a/src/main/java/pie/tomato/tomatomarket/domain/Member.java
+++ b/src/main/java/pie/tomato/tomatomarket/domain/Member.java
@@ -1,0 +1,23 @@
+package pie.tomato.tomatomarket.domain;
+
+import static javax.persistence.GenerationType.*;
+import static lombok.AccessLevel.*;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+public class Member {
+
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	private Long id;
+	private String loginId;
+	private String email;
+	private String profile;
+
+}

--- a/src/main/java/pie/tomato/tomatomarket/domain/MemberTown.java
+++ b/src/main/java/pie/tomato/tomatomarket/domain/MemberTown.java
@@ -1,0 +1,31 @@
+package pie.tomato.tomatomarket.domain;
+
+import static javax.persistence.FetchType.*;
+import static javax.persistence.GenerationType.*;
+import static lombok.AccessLevel.*;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+public class MemberTown {
+
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	private Long id;
+	private String name;
+
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
+
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(name = "region_id")
+	private Region region;
+}

--- a/src/main/java/pie/tomato/tomatomarket/domain/Region.java
+++ b/src/main/java/pie/tomato/tomatomarket/domain/Region.java
@@ -1,0 +1,21 @@
+package pie.tomato.tomatomarket.domain;
+
+import static javax.persistence.GenerationType.*;
+import static lombok.AccessLevel.*;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+public class Region {
+
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	private Long id;
+	private String name;
+
+}

--- a/src/main/java/pie/tomato/tomatomarket/domain/Wish.java
+++ b/src/main/java/pie/tomato/tomatomarket/domain/Wish.java
@@ -1,0 +1,30 @@
+package pie.tomato.tomatomarket.domain;
+
+import static javax.persistence.FetchType.*;
+import static javax.persistence.GenerationType.*;
+import static lombok.AccessLevel.*;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+public class Wish {
+
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
+
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(name = "item_id")
+	private Item item;
+}


### PR DESCRIPTION
## Issues
- #2 

## What is this PR? 👓
엔티티 클래스를 생성 했습니다.

## 공부하면서 배웠던 것
### 📌 1.  @Entity 클래스에 @NoArgsConstructor(기본생성자)가 필요한 이유
JPA 공식 문서에는 Entity Class의 요구사항에 대해 다음과 같은 내용이 포함되어 있다.

![image](https://github.com/pie2457/Tomato-market/assets/104147789/d07d6ee1-e37b-4461-880b-aa05602a5bd9)
JPA는 Entity 객체를 인스턴스화 하고 필드에 값을 채워넣기 위해 ***Reflection**을 사용해, 
런타임 시점에 동적으로 기본생성자를 통해  클래스를 인스턴스화하여 값을 매핑하기 때문에 기본 생성자를 만들어야한다.

### 📌 2. JPA의 Entity Class에서 기본 생성자의 access level을 Private가 아닌 Public 또는 Protected로 제한하는 이유는 무엇일까?
JPA는 다른 Entity와 연관관계를 갖는 Entity를 조회할 때 
1. 연관된 Entity 객체를 함께 가져오는 즉시로딩(EAGER)
2. 연관된 Entity 객체를 실제로 조회할 때 가져오는 지연로딩(LAZY)

두 가지 전략을 선택하여 사용할 수 있다.

연관관계를 갖는 Entity를 LAZY(지연로딩)로 설정하게 되면 Entity 객체는 Proxy 객체로 가져오게 되는데,
이 때 Proxy 객체는 Entity Class를 상속받아 만들어진 객체이므로 Entity의 기본생성자에 대한 접근제어자가 Private일 시
Entity Class를 상속 받을 수 없어 Proxy 객체를 생성 할 수 없다.
#### 즉, JPA가 Entity Class를 상속받는 Proxy 객체를 생성하기 위해 Entity Class의 기본생성자는 Public 또는 Protected의 접근제어자를 가져야 한다.
---
### Reflection이란?
java에서는 reflection이라는 api를 제공한다.
reflection은 구체적인 클래스 타입을 알지 못해도 클래스의 메서드나, 타입, 변수들에 접근할 수 있도록 해주는 api이다.

대표적인 적용 예시로는
1. JPA에서 객체 조회시 데이터가 들어가는 것
2. @RequestBody 사용 시 DTO 객체에 데이터가 들어가는 것
3. 테스트 케이스 작성시 private 메서드를 테스트할 때 등이 있다.