### PR TITLE
[feat] jwt 생성 및 검증

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/pie/tomato/config/PropertiesConfig.java
+++ b/src/main/java/pie/tomato/config/PropertiesConfig.java
@@ -1,0 +1,9 @@
+package pie.tomato.config;
+
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.Configuration;
+
+@ConfigurationPropertiesScan("pie.tomato.tomatomarket.infrastructure.config.properties")
+@Configuration
+public class PropertiesConfig {
+}

--- a/src/main/java/pie/tomato/tomatomarket/domain/ChatLog.java
+++ b/src/main/java/pie/tomato/tomatomarket/domain/ChatLog.java
@@ -30,5 +30,4 @@ public class ChatLog {
 	@ManyToOne(fetch = LAZY)
 	@JoinColumn(name = "chatroom_id")
 	private Chatroom chatroom;
-
 }

--- a/src/main/java/pie/tomato/tomatomarket/domain/Chatroom.java
+++ b/src/main/java/pie/tomato/tomatomarket/domain/Chatroom.java
@@ -30,5 +30,4 @@ public class Chatroom {
 	@ManyToOne(fetch = LAZY)
 	@JoinColumn(name = "item_id")
 	private Item item;
-
 }

--- a/src/main/java/pie/tomato/tomatomarket/domain/Member.java
+++ b/src/main/java/pie/tomato/tomatomarket/domain/Member.java
@@ -19,5 +19,4 @@ public class Member {
 	private String loginId;
 	private String email;
 	private String profile;
-
 }

--- a/src/main/java/pie/tomato/tomatomarket/domain/Region.java
+++ b/src/main/java/pie/tomato/tomatomarket/domain/Region.java
@@ -17,5 +17,4 @@ public class Region {
 	@GeneratedValue(strategy = IDENTITY)
 	private Long id;
 	private String name;
-
 }

--- a/src/main/java/pie/tomato/tomatomarket/exception/ErrorCode.java
+++ b/src/main/java/pie/tomato/tomatomarket/exception/ErrorCode.java
@@ -1,0 +1,19 @@
+package pie.tomato.tomatomarket.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+	// JWT
+	INVALID_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰입니다."),
+	EMPTY_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다."),
+	EXPIRED_TOKEN(HttpStatus.FORBIDDEN, "토큰이 만료되었습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/src/main/java/pie/tomato/tomatomarket/exception/TomatoMarketException.java
+++ b/src/main/java/pie/tomato/tomatomarket/exception/TomatoMarketException.java
@@ -1,0 +1,11 @@
+package pie.tomato.tomatomarket.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class TomatoMarketException extends RuntimeException {
+
+	private final ErrorCode errorCode;
+}

--- a/src/main/java/pie/tomato/tomatomarket/exception/UnAuthorizedException.java
+++ b/src/main/java/pie/tomato/tomatomarket/exception/UnAuthorizedException.java
@@ -1,0 +1,8 @@
+package pie.tomato.tomatomarket.exception;
+
+public class UnAuthorizedException extends TomatoMarketException {
+
+	public UnAuthorizedException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/config/jwt/JwtProvider.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/config/jwt/JwtProvider.java
@@ -1,0 +1,55 @@
+package pie.tomato.tomatomarket.infrastructure.config.jwt;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.Map;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import pie.tomato.tomatomarket.exception.ErrorCode;
+import pie.tomato.tomatomarket.exception.UnAuthorizedException;
+import pie.tomato.tomatomarket.infrastructure.config.properties.JwtProperties;
+
+@Component
+public class JwtProvider {
+
+	private final SecretKey secretKey;
+	private final long accessTokenExpirationTime;
+
+	public JwtProvider(JwtProperties jwtProperties) {
+		this.secretKey = Keys.hmacShaKeyFor(jwtProperties.getSecretKey().getBytes(StandardCharsets.UTF_8));
+		this.accessTokenExpirationTime = jwtProperties.getAccessTokenExpirationTime();
+	}
+
+	public String createAccessToken(Long memberId) {
+		Date now = new Date();
+		Date accessTokenExpiration = new Date(now.getTime() + accessTokenExpirationTime);
+
+		return Jwts.builder()
+			.signWith(secretKey, SignatureAlgorithm.HS256)
+			.setIssuedAt(now)
+			.setExpiration(accessTokenExpiration)
+			.setClaims(Map.of("memberId", memberId))
+			.compact();
+	}
+
+	public void validateToken(final String token) {
+		try {
+			Jwts.parserBuilder()
+				.setSigningKey(secretKey)
+				.build()
+				.parseClaimsJws(token);
+		} catch (ExpiredJwtException e) {
+			throw new UnAuthorizedException(ErrorCode.EXPIRED_TOKEN);
+		} catch (JwtException e) {
+			throw new UnAuthorizedException(ErrorCode.INVALID_TOKEN);
+		}
+	}
+}

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/config/jwt/JwtProvider.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/config/jwt/JwtProvider.java
@@ -36,7 +36,7 @@ public class JwtProvider {
 			.signWith(secretKey, SignatureAlgorithm.HS256)
 			.setIssuedAt(now)
 			.setExpiration(accessTokenExpiration)
-			.setClaims(Map.of("memberId", memberId))
+			.addClaims(Map.of("memberId", memberId))
 			.compact();
 	}
 

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/config/properties/JwtProperties.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/config/properties/JwtProperties.java
@@ -1,0 +1,22 @@
+package pie.tomato.tomatomarket.infrastructure.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+import lombok.Getter;
+
+@Getter
+@ConfigurationProperties("jwt")
+public class JwtProperties {
+
+	private final String secretKey;
+	private final long accessTokenExpirationTime;
+	private final long refreshTokenExpirationTime;
+
+	@ConstructorBinding
+	public JwtProperties(String secretKey, long accessTokenExpirationTime, long refreshTokenExpirationTime) {
+		this.secretKey = secretKey;
+		this.accessTokenExpirationTime = accessTokenExpirationTime;
+		this.refreshTokenExpirationTime = refreshTokenExpirationTime;
+	}
+}

--- a/src/main/java/pie/tomato/tomatomarket/presentation/filter/JwtFilter.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/filter/JwtFilter.java
@@ -12,6 +12,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpHeaders;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.StringUtils;
+import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import pie.tomato.tomatomarket.exception.ErrorCode;
@@ -40,6 +41,11 @@ public class JwtFilter extends OncePerRequestFilter {
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
 		FilterChain filterChain) throws ServletException, IOException {
+		if (CorsUtils.isPreFlightRequest(request)) {
+			filterChain.doFilter(request, response);
+			return;
+		}
+
 		String token = extractJwt(request)
 			.orElseThrow(() -> new UnAuthorizedException(ErrorCode.INVALID_TOKEN));
 		jwtProvider.validateToken(token);

--- a/src/main/java/pie/tomato/tomatomarket/presentation/filter/JwtFilter.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/filter/JwtFilter.java
@@ -1,0 +1,57 @@
+package pie.tomato.tomatomarket.presentation.filter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import pie.tomato.tomatomarket.exception.ErrorCode;
+import pie.tomato.tomatomarket.exception.UnAuthorizedException;
+import pie.tomato.tomatomarket.infrastructure.config.jwt.JwtProvider;
+
+public class JwtFilter extends OncePerRequestFilter {
+
+	private static final String BEARER = "bearer";
+
+	private final AntPathMatcher pathMatcher = new AntPathMatcher();
+	private final List<String> excludeUrlPatterns = List.of("/api/auth/**");
+
+	private final JwtProvider jwtProvider;
+
+	public JwtFilter(JwtProvider jwtProvider) {
+		this.jwtProvider = jwtProvider;
+	}
+
+	@Override
+	protected boolean shouldNotFilter(HttpServletRequest request) {
+		return excludeUrlPatterns.stream()
+			.anyMatch(pattern -> pathMatcher.match(pattern, request.getRequestURI()));
+	}
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+		String token = extractJwt(request)
+			.orElseThrow(() -> new UnAuthorizedException(ErrorCode.INVALID_TOKEN));
+		jwtProvider.validateToken(token);
+
+		filterChain.doFilter(request, response);
+	}
+
+	private Optional<String> extractJwt(HttpServletRequest request) {
+		final String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+		if (!StringUtils.hasText(header) || !header.toLowerCase().startsWith(BEARER)) {
+			return Optional.empty();
+		}
+		return Optional.of(header.split(" ")[1]);
+	}
+}

--- a/src/test/java/pie/tomato/tomatomarket/infrastructure/config/jwt/JwtProviderTest.java
+++ b/src/test/java/pie/tomato/tomatomarket/infrastructure/config/jwt/JwtProviderTest.java
@@ -1,0 +1,39 @@
+package pie.tomato.tomatomarket.infrastructure.config.jwt;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import pie.tomato.tomatomarket.exception.ErrorCode;
+import pie.tomato.tomatomarket.exception.UnAuthorizedException;
+import pie.tomato.tomatomarket.infrastructure.config.properties.JwtProperties;
+
+class JwtProviderTest {
+
+	private final String secretKey = "1e57a452a094728c291bc42bf2bc7eb8d9fd8844d1369da2bf728588b46c4e75";
+	private final JwtProvider jwtProvider = new JwtProvider(
+		new JwtProperties(secretKey, 100000, 100000));
+
+	@Test
+	@DisplayName("회원의 ID가 주어지면 토큰을 생성한다.")
+	void createToken() {
+		// given
+		String accessToken = jwtProvider.createAccessToken(1L);
+
+		// when & then
+		assertThat(accessToken).isNotBlank();
+	}
+
+	@Test
+	@DisplayName("잘못된 토큰이 들어오면 예외가 던져진다.")
+	void invalidToken() {
+		// given
+		String invalidToken = "qwe.123.q12ew2";
+
+		// when & then
+		assertThatThrownBy(
+			() -> jwtProvider.validateToken(invalidToken)).isInstanceOf(UnAuthorizedException.class)
+			.extracting("ErrorCode").isEqualTo(ErrorCode.INVALID_TOKEN);
+	}
+}


### PR DESCRIPTION
## Issues
- #4 

## What is this PR? 👓
- jwt 생성 및 검증에 대한 PR입니다.

## Key changes 🔑
- jwt 생성
  - jwt라이브러리를 이용하여 토큰을 생성합니다.
- jwt 검증
  - jwt 서버에서 발급한 토큰인지, 유효한지 등을 검증합니다.
- jwt 테스트코드 작성
  - jwt 생성 및 검증에 관한 테스트를 작성했습니다.  

## 📖 공부하면서 배웠던 것
### 📌 CORS
Cross-Origin Resource Sharing은 말 그대로 origin이 다른 경우에도 리소스를 공유할 수 있게 허용해주는 정책을 뜻한다.
여기서 origin은 프로토콜 + 호스트 + 포트 번호를 합한 것으로 이 세가지가 동일하면 같은 origin이라고 판단한다.
예를 들어, `http://123.456.789.123:3000`과 `http://123.456.789.123:8001`은 다른 origin이다.

프론트엔드와 백엔드가 분리되어 있지 않던 시절에는 프론트와 백엔드가 서로 같은 origin에 있었는데, 
프론트와 백엔드가 분리가 되어 각기 다른 서버에 존재하기 시작하면서 문제가 발생하기 시작했다. 
별도로 존재하는 프론트엔드 서버에서 백엔드 서버로 요청(request)을 보내야 하는 상황이 되었고,  
동시에 백엔드 서버에서는 어떤 곳에서 요청을 보내는지 알 수 없게 되었다. 
따라서 백엔드 서버쪽에서 어떤 origin에서 요청을 했을 때 받아 줄 것인지 허용 origin에 대해 정의해줄 필요가 생긴 것이다.
> 백엔드 서버 : "나는 이 origin에서 이뤄지는 요청만 처리해줄거야. 다른 origin은 믿을 수 없어 해커가 날 공격할 수 도 있잖아?"

그런데 일단 프론트엔드에서 백엔드쪽으로 요청을 보낸 이후에만 허용된 origin인지 아닌지를 알 수 있는 상황이어서 문제가 되었다.
애초에 요청 자체를 못하게 막을 방법이 필요했고,  그래서 나온것이 `preflight request`이다.
### 📌 Preflight Request
preflight request는 실제 요청전에 브라우저에서 보내는 작은 요청이다.  
지금 요청을 보내는 프론트엔드가 백엔드 서버에서 허용한 origin이 맞는지, 
그리고 해당 엔드포인트에서 어떤 HTTP메서드들을 허용하는지 등을 확인한다.
만약 허용되는 origin 요청이고 메서드도 허용되는 것이라면 실제 요청을 할 수 있게 해준다. 
그렇지않다면, 실제 요청을 보내기도 전에 보내지 못하게 막는 것이다. 아래 그림을 보면 preflight request가 무엇인지 이해하는데 도움이된다.

<img src="https://github.com/pie2457/Tomato-market/assets/104147789/8e81230b-be14-43d1-afd8-34fff3dbdf0a" width="450" height="450">

### 📌 Filter
![image](https://github.com/pie2457/Tomato-market/assets/104147789/477dd638-bdf1-4f14-ad3c-c7912dc4ba85)
필터는 디스패처 서블릿(Dispatcher Servlet)에 요청이 전달되기 전에 url 패턴에 맞는 모든 요청에 대해 부가 작업을 처리할 수 있는 기능을 제공한다. 즉, 스프링 컨테이너가 아닌 톰캣과 같은 웹 컨테이너에 의해 관리가 되므로 조건에 부합하지 않는 요청이 들어오면 스프링 내부에 있는 디스패처 서블릿으로 가기 전에 필터에서 요청을 필터링 처리하는 것이다.