### PR TITLE
[feat] 닉네임 변경 기능 구현

### DIFF
--- a/src/main/java/pie/tomato/tomatomarket/application/AuthService.java
+++ b/src/main/java/pie/tomato/tomatomarket/application/AuthService.java
@@ -9,6 +9,7 @@ import pie.tomato.tomatomarket.domain.Member;
 import pie.tomato.tomatomarket.domain.oauth.OAuthUser;
 import pie.tomato.tomatomarket.exception.BadRequestException;
 import pie.tomato.tomatomarket.exception.ErrorCode;
+import pie.tomato.tomatomarket.exception.NotFoundException;
 import pie.tomato.tomatomarket.infrastructure.config.jwt.JwtProvider;
 import pie.tomato.tomatomarket.infrastructure.persistence.MemberRepository;
 
@@ -33,7 +34,7 @@ public class AuthService {
 		String accessToken = kakaoClient.getAccessToken(code);
 		OAuthUser oAuthUser = kakaoClient.getUserInfo(accessToken);
 		Member member = memberRepository.findByEmail(oAuthUser.getEmail())
-			.orElseThrow(() -> new BadRequestException(ErrorCode.NOT_FOUND_MEMBER));
+			.orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_MEMBER));
 		return jwtProvider.createAccessToken(member.getId());
 	}
 

--- a/src/main/java/pie/tomato/tomatomarket/application/MemberService.java
+++ b/src/main/java/pie/tomato/tomatomarket/application/MemberService.java
@@ -1,0 +1,33 @@
+package pie.tomato.tomatomarket.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import pie.tomato.tomatomarket.domain.Member;
+import pie.tomato.tomatomarket.exception.BadRequestException;
+import pie.tomato.tomatomarket.exception.ErrorCode;
+import pie.tomato.tomatomarket.exception.NotFoundException;
+import pie.tomato.tomatomarket.infrastructure.persistence.MemberRepository;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberService {
+
+	private final MemberRepository memberRepository;
+
+	@Transactional
+	public void modifyNickname(Long memberId, String nickname) {
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_MEMBER));
+		existsNickname(nickname);
+		member.changeNickname(nickname);
+	}
+
+	private void existsNickname(String nickname) {
+		if (memberRepository.existsByNickname(nickname)) {
+			throw new BadRequestException(ErrorCode.ALREADY_EXIST_NICKNAME);
+		}
+	}
+}

--- a/src/main/java/pie/tomato/tomatomarket/application/oauth/KakaoClient.java
+++ b/src/main/java/pie/tomato/tomatomarket/application/oauth/KakaoClient.java
@@ -14,13 +14,12 @@ import lombok.RequiredArgsConstructor;
 import pie.tomato.tomatomarket.domain.oauth.OAuthUser;
 import pie.tomato.tomatomarket.infrastructure.config.properties.OauthProperties;
 
-@RequiredArgsConstructor
 @Component
+@RequiredArgsConstructor
 public class KakaoClient {
 
 	private final OauthProperties kakao;
 	private final RestTemplate restTemplate;
-	private final OAuthUser oAuthUser;
 
 	public String getAccessToken(String code) {
 		HttpHeaders headers = new HttpHeaders();

--- a/src/main/java/pie/tomato/tomatomarket/domain/Member.java
+++ b/src/main/java/pie/tomato/tomatomarket/domain/Member.java
@@ -27,4 +27,8 @@ public class Member {
 		this.email = email;
 		this.profile = profile;
 	}
+
+	public void changeNickname(String nickname) {
+		this.nickname = nickname;
+	}
 }

--- a/src/main/java/pie/tomato/tomatomarket/exception/ErrorCode.java
+++ b/src/main/java/pie/tomato/tomatomarket/exception/ErrorCode.java
@@ -16,7 +16,8 @@ public enum ErrorCode {
 
 	// Member
 	ALREADY_EXIST_MEMBER(HttpStatus.BAD_REQUEST, "이미 가입된 회원입니다."),
-	NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "회원을 찾지 못하였습니다.");
+	NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "회원을 찾지 못하였습니다."),
+	ALREADY_EXIST_NICKNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/src/main/java/pie/tomato/tomatomarket/exception/NotFoundException.java
+++ b/src/main/java/pie/tomato/tomatomarket/exception/NotFoundException.java
@@ -1,0 +1,8 @@
+package pie.tomato.tomatomarket.exception;
+
+public class NotFoundException extends TomatoMarketException {
+
+	public NotFoundException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/config/RestTemplateConfig.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package pie.tomato.tomatomarket.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+	@Bean
+	public RestTemplate restTemplate() {
+		return new RestTemplate();
+	}
+}

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/MemberRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/MemberRepository.java
@@ -10,6 +10,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
 	boolean existsMemberByEmail(String email);
 
-	Optional<Member> findByEmail(String eamil);
+	Optional<Member> findByEmail(String email);
+
+	boolean existsByNickname(String nickname);
 
 }

--- a/src/main/java/pie/tomato/tomatomarket/presentation/AuthController.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/AuthController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 import pie.tomato.tomatomarket.application.AuthService;
-import pie.tomato.tomatomarket.application.oauth.response.LoginResponse;
+import pie.tomato.tomatomarket.presentation.response.LoginResponse;
 
 @RequiredArgsConstructor
 @RestController

--- a/src/main/java/pie/tomato/tomatomarket/presentation/MemberController.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/MemberController.java
@@ -1,0 +1,27 @@
+package pie.tomato.tomatomarket.presentation;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import pie.tomato.tomatomarket.application.MemberService;
+import pie.tomato.tomatomarket.presentation.request.NicknameModifyRequest;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/members")
+public class MemberController {
+
+	private final MemberService memberService;
+
+	@PutMapping("/{memberId}")
+	public ResponseEntity<Void> modifyNickname(@PathVariable Long memberId,
+		@RequestBody NicknameModifyRequest request) {
+		memberService.modifyNickname(memberId, request.getNickname());
+		return ResponseEntity.ok().build();
+	}
+}

--- a/src/main/java/pie/tomato/tomatomarket/presentation/request/NicknameModifyRequest.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/request/NicknameModifyRequest.java
@@ -1,0 +1,12 @@
+package pie.tomato.tomatomarket.presentation.request;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class NicknameModifyRequest {
+
+	private String nickname;
+}

--- a/src/main/java/pie/tomato/tomatomarket/presentation/response/LoginResponse.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/response/LoginResponse.java
@@ -1,10 +1,11 @@
-package pie.tomato.tomatomarket.application.oauth.response;
+package pie.tomato.tomatomarket.presentation.response;
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
+@Getter
 @AllArgsConstructor
 public class LoginResponse {
 
 	private String accessToken;
-
 }

--- a/src/test/java/pie/tomato/tomatomarket/application/MemberServiceTest.java
+++ b/src/test/java/pie/tomato/tomatomarket/application/MemberServiceTest.java
@@ -1,0 +1,37 @@
+package pie.tomato.tomatomarket.application;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import pie.tomato.tomatomarket.domain.Member;
+import pie.tomato.tomatomarket.support.SupportRepository;
+
+@Transactional
+@SpringBootTest
+class MemberServiceTest {
+
+	@Autowired
+	private MemberService memberService;
+	@Autowired
+	private SupportRepository supportRepository;
+
+	@DisplayName("사용자의 닉네임 변경 요청에 성공한다.")
+	@Test
+	void editNickname() {
+		// given
+		Member member = supportRepository.save(
+			new Member("123piepiepie123", "pie_choco@pie.com", "pie/image.jpg"));
+
+		// when
+		memberService.modifyNickname(member.getId(), "파이에오");
+
+		// then
+		Member editMember = supportRepository.findById(member.getId(), Member.class);
+		assertThat(editMember.getNickname()).isEqualTo("파이에오");
+	}
+}

--- a/src/test/java/pie/tomato/tomatomarket/application/unit/AuthServiceTest.java
+++ b/src/test/java/pie/tomato/tomatomarket/application/unit/AuthServiceTest.java
@@ -1,4 +1,4 @@
-package pie.tomato.tomatomarket.application;
+package pie.tomato.tomatomarket.application.unit;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
@@ -12,6 +12,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.transaction.annotation.Transactional;
 
+import pie.tomato.tomatomarket.application.AuthService;
 import pie.tomato.tomatomarket.application.oauth.KakaoClient;
 import pie.tomato.tomatomarket.domain.oauth.OAuthUser;
 import pie.tomato.tomatomarket.exception.BadRequestException;

--- a/src/test/java/pie/tomato/tomatomarket/support/SupportRepository.java
+++ b/src/test/java/pie/tomato/tomatomarket/support/SupportRepository.java
@@ -1,0 +1,32 @@
+package pie.tomato.tomatomarket.support;
+
+import java.util.List;
+
+import javax.persistence.EntityManager;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@Transactional
+public class SupportRepository {
+
+	@Autowired
+	private EntityManager em;
+
+	public <T> T save(T entity) {
+		em.persist(entity);
+		em.flush();
+		em.clear();
+		return entity;
+	}
+
+	public <T> T findById(Long id, Class<T> entityClass) {
+		return em.find(entityClass, id);
+	}
+
+	public <T> List<T> findAll(Class<T> entityClass) {
+		return em.createQuery("select entity from " + entityClass.getSimpleName() + " entity").getResultList();
+	}
+}


### PR DESCRIPTION
## Issues
- #8 

## What is this PR? 👓
- 닉네임을 변경할 수 있는 기능을 구현했습니다.
  - 프론트가 없어서 카카오에서 가져온 사용자의 `nickname`에 `RandomUUID`를 붙여 임의로 닉네임 생성 후 사용자가 원하는 닉네임으로 변경할 수 있게끔 수정하였습니다.

## 📖 공부하면서 배웠던 것
로그인 api를 테스트 하던 중 `HttpMediaTypeNotAcceptableException (에러코드 406)`이 발생하여 에러코드를 찾아보니  
<img width="794" alt="스크린샷 2023-10-18 오후 3 08 47" src="https://github.com/pie2457/Tomato-market/assets/104147789/7922727b-ef93-4f41-9162-c65419fa94d1">
`406 에러`는 **서버가 허용된 타입의 응답을 생성하지 못할 때 발생하는 통신 에러**라는 것을 확인했습니다.
다음으로 `HttpMediaTypeNotAcceptableException`이 발생한 이유를 찾아보니 
![image](https://github.com/pie2457/Tomato-market/assets/104147789/4e4b1928-9428-4b8f-99e2-fcb33dda76f5)
**요청 핸들러가 허용된 응답을 만들어낼 수 없을 때 발생하는 에러**였습니다.
### 📌 해결방법
응답을 만들어 낼 수 없을때라는 걸 확인하고 `LoginResponse` 객체에 `@Getter`애노테이션을 달아 문제를 해결했습니다.
여기서 왜 `@Getter`가 있어야하는지 의문이 생겨 찾아 본 결과, `Jackson`라이브러리는 내부적으로 ObjectMapping API를 사용하여 객체를 json형식으로 변환하는데 `Jackson`라이브러리는 `Getter/Setter` 프로퍼티 기준으로 작동합니다. 
별다른 옵션을 주지 않는 한 `Getter/Setter`를 사용하여 변환작업을 수행하는데 `LoginResponse`에 `getter`가 없어 `json`형태로 값을 변환해주지 못해 에러가 발생된거라 생각하고 `@Getter` 애노테이션을 붙여주었습니다.

* 참고 : `spring-boot-stater-web` 의존성을 주입하면 `Jackson` 라이브러리가 자동으로 포함된다.
