### PR TITLE
[feat] 이미지 업로드 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,9 +28,16 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    // jwt
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // S3
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.518'
+    testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.518'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/pie/tomato/tomatomarket/application/ImageService.java
+++ b/src/main/java/pie/tomato/tomatomarket/application/ImageService.java
@@ -1,0 +1,28 @@
+package pie.tomato.tomatomarket.application;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.RequiredArgsConstructor;
+import pie.tomato.tomatomarket.domain.ImageFile;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ImageService {
+
+	private final ImageUploader imageUploader;
+
+	public String uploadImageToS3(MultipartFile multipartFile) {
+		ImageFile file = ImageFile.from(multipartFile);
+		return imageUploader.uploadImageToS3(file);
+	}
+
+	public List<String> uploadImagesToS3(List<MultipartFile> multipartFiles) {
+		List<ImageFile> imageFiles = ImageFile.from(multipartFiles);
+		return imageUploader.uploadImagesToS3(imageFiles);
+	}
+}

--- a/src/main/java/pie/tomato/tomatomarket/application/ImageUploader.java
+++ b/src/main/java/pie/tomato/tomatomarket/application/ImageUploader.java
@@ -1,0 +1,55 @@
+package pie.tomato.tomatomarket.application;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+
+import pie.tomato.tomatomarket.domain.ImageFile;
+import pie.tomato.tomatomarket.infrastructure.config.properties.S3Properties;
+
+@Component
+public class ImageUploader {
+
+	private static final String UPLOADED_IMAGES_DIR = "public/";
+
+	private final AmazonS3Client amazonS3Client;
+	private final String bucket;
+
+	public ImageUploader(AmazonS3Client amazonS3Client, S3Properties s3Properties) {
+		this.amazonS3Client = amazonS3Client;
+		this.bucket = s3Properties.getS3().getBucket();
+	}
+
+	public String uploadImageToS3(ImageFile imageFile) {
+		final String fileName = putImage(imageFile);
+		return getObjectUrl(fileName);
+	}
+
+	public List<String> uploadImagesToS3(List<ImageFile> imageFile) {
+		List<String> urls = new ArrayList<>();
+		for (ImageFile file : imageFile) {
+			final String fileName = putImage(file);
+			urls.add(getObjectUrl(fileName));
+		}
+		return urls;
+	}
+
+	private String putImage(ImageFile imageFile) {
+		ObjectMetadata metadata = new ObjectMetadata();
+		metadata.setContentType(imageFile.getContentType());
+
+		final String fileName = UPLOADED_IMAGES_DIR + imageFile.getFileName();
+		amazonS3Client.putObject(bucket, fileName, imageFile.getImageInputStream(), metadata);
+		return fileName;
+	}
+
+	private String getObjectUrl(final String fileName) {
+		return URLDecoder.decode(amazonS3Client.getUrl(bucket, fileName).toString(), StandardCharsets.UTF_8);
+	}
+}

--- a/src/main/java/pie/tomato/tomatomarket/domain/ImageFile.java
+++ b/src/main/java/pie/tomato/tomatomarket/domain/ImageFile.java
@@ -1,0 +1,90 @@
+package pie.tomato.tomatomarket.domain;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import pie.tomato.tomatomarket.exception.BadRequestException;
+import pie.tomato.tomatomarket.exception.ErrorCode;
+import pie.tomato.tomatomarket.exception.InternalServerException;
+
+@Getter
+@RequiredArgsConstructor
+public class ImageFile {
+
+	private final String fileName;
+	private final String contentType;
+	private final Long fileSize;
+	private final InputStream imageInputStream;
+
+	public ImageFile(MultipartFile multipartFile) {
+		this.fileName = getFileName(multipartFile);
+		this.contentType = getImageContentType(multipartFile);
+		this.imageInputStream = getImageInputStream(multipartFile);
+		this.fileSize = multipartFile.getSize();
+	}
+
+	public static ImageFile from(MultipartFile multipartFile) {
+		return new ImageFile(multipartFile);
+	}
+
+	public static List<ImageFile> from(List<MultipartFile> multipartFiles) {
+		List<ImageFile> imageFiles = new ArrayList<>();
+		for (MultipartFile multipartFile : multipartFiles) {
+			imageFiles.add(new ImageFile(multipartFile));
+		}
+		return imageFiles;
+	}
+
+	public InputStream getImageInputStream(MultipartFile multipartFile) {
+		try {
+			return multipartFile.getInputStream();
+		} catch (IOException e) {
+			throw new InternalServerException(ErrorCode.FILE_IO_EXCEPTION);
+		}
+	}
+
+	private String getImageContentType(MultipartFile multipartFile) {
+		return ImageContentType.findEnum(StringUtils.getFilenameExtension(multipartFile.getOriginalFilename()));
+	}
+
+	private String getFileName(MultipartFile multipartFile) {
+		String ext = extractExt(multipartFile.getOriginalFilename());
+		String uuid = UUID.randomUUID().toString();
+		return uuid + "." + ext;
+	}
+
+	private String extractExt(String originalFilename) {
+		int pos = originalFilename.lastIndexOf(".");
+		return originalFilename.substring(pos + 1);
+	}
+
+	@Getter
+	@RequiredArgsConstructor
+	enum ImageContentType {
+
+		JPEG("jpeg"),
+		JPG("jpg"),
+		PNG("png"),
+		SVG("svg");
+
+		private final String contentType;
+
+		public static String findEnum(String contentType) {
+
+			for (ImageContentType imageContentType : ImageContentType.values()) {
+				if (imageContentType.getContentType().equals(contentType.toLowerCase())) {
+					return imageContentType.getContentType();
+				}
+			}
+			throw new BadRequestException(ErrorCode.INVALID_FILE_EXTENSION);
+		}
+	}
+}

--- a/src/main/java/pie/tomato/tomatomarket/domain/ImageFile.java
+++ b/src/main/java/pie/tomato/tomatomarket/domain/ImageFile.java
@@ -78,9 +78,8 @@ public class ImageFile {
 		private final String contentType;
 
 		public static String findEnum(String contentType) {
-
 			for (ImageContentType imageContentType : ImageContentType.values()) {
-				if (imageContentType.getContentType().equals(contentType.toLowerCase())) {
+				if (imageContentType.getContentType().equalsIgnoreCase(contentType)) {
 					return imageContentType.getContentType();
 				}
 			}

--- a/src/main/java/pie/tomato/tomatomarket/domain/ImageFile.java
+++ b/src/main/java/pie/tomato/tomatomarket/domain/ImageFile.java
@@ -24,7 +24,7 @@ public class ImageFile {
 	private final Long fileSize;
 	private final InputStream imageInputStream;
 
-	public ImageFile(MultipartFile multipartFile) {
+	private ImageFile(MultipartFile multipartFile) {
 		this.fileName = getFileName(multipartFile);
 		this.contentType = getImageContentType(multipartFile);
 		this.imageInputStream = getImageInputStream(multipartFile);

--- a/src/main/java/pie/tomato/tomatomarket/exception/ErrorCode.java
+++ b/src/main/java/pie/tomato/tomatomarket/exception/ErrorCode.java
@@ -17,7 +17,11 @@ public enum ErrorCode {
 	// Member
 	ALREADY_EXIST_MEMBER(HttpStatus.BAD_REQUEST, "이미 가입된 회원입니다."),
 	NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "회원을 찾지 못하였습니다."),
-	ALREADY_EXIST_NICKNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다.");
+	ALREADY_EXIST_NICKNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
+
+	// Image
+	INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 확장자입니다."),
+	FILE_IO_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "파일 입출력에 실패했습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/src/main/java/pie/tomato/tomatomarket/exception/InternalServerException.java
+++ b/src/main/java/pie/tomato/tomatomarket/exception/InternalServerException.java
@@ -1,0 +1,8 @@
+package pie.tomato.tomatomarket.exception;
+
+public class InternalServerException extends TomatoMarketException {
+
+	public InternalServerException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/config/S3Config.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/config/S3Config.java
@@ -1,0 +1,26 @@
+package pie.tomato.tomatomarket.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+import pie.tomato.tomatomarket.infrastructure.config.properties.S3Properties;
+
+@Configuration
+public class S3Config {
+
+	@Bean
+	public AmazonS3Client amazonS3Client(S3Properties s3Properties) {
+		BasicAWSCredentials credentials = new BasicAWSCredentials(s3Properties.getCredentials().getAccessKey(),
+			s3Properties.getCredentials().getSecretKey());
+
+		return (AmazonS3Client)AmazonS3ClientBuilder.standard()
+			.withCredentials(new AWSStaticCredentialsProvider(credentials))
+			.withRegion(s3Properties.getRegion())
+			.build();
+	}
+}

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/config/properties/S3Properties.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/config/properties/S3Properties.java
@@ -1,0 +1,39 @@
+package pie.tomato.tomatomarket.infrastructure.config.properties;
+
+import java.util.Map;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@ConfigurationProperties("cloud.aws")
+public class S3Properties {
+
+	private final Credentials credentials;
+	private final S3 s3;
+	private final String region;
+
+	@ConstructorBinding
+	public S3Properties(Credentials credentials, S3 s3, Map<String, String> region) {
+		this.credentials = credentials;
+		this.s3 = s3;
+		this.region = region.get("static");
+	}
+
+	@Getter
+	@RequiredArgsConstructor
+	public static class Credentials {
+
+		private final String accessKey;
+		private final String secretKey;
+	}
+
+	@Getter
+	@RequiredArgsConstructor
+	public static class S3 {
+		private final String bucket;
+	}
+}

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/config/properties/S3Properties.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/config/properties/S3Properties.java
@@ -34,6 +34,7 @@ public class S3Properties {
 	@Getter
 	@RequiredArgsConstructor
 	public static class S3 {
+		
 		private final String bucket;
 	}
 }

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/config/properties/S3Properties.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/config/properties/S3Properties.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
-@ConfigurationProperties("cloud.aws")
+@ConfigurationProperties("aws")
 public class S3Properties {
 
 	private final Credentials credentials;

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -6,12 +6,12 @@ spring:
 
 cloud:
   aws:
-    credential:
-      access-key: ${cloud.aws.credential.access-key}
-      secret-key: ${cloud.aws.credential.secret-key}
+    credentials:
+      access-key: ${aws.credentials.access-key}
+      secret-key: ${aws.credentials.secret-key}
     s3:
-      bucket: ${cloud.aws.s3.bucket}
+      bucket: ${aws.s3.bucket}
     region:
-      static: ${cloud.aws.region.static}
+      static: ${aws.region.static}
   stack:
     auto: false

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -3,3 +3,15 @@ spring:
     url: ${db.dev.datasource.url}
     username: ${db.dev.datasource.username}
     password: ${db.dev.datasource.password}
+
+cloud:
+  aws:
+    credential:
+      access-key: ${cloud.aws.credential.access-key}
+      secret-key: ${cloud.aws.credential.secret-key}
+    s3:
+      bucket: ${cloud.aws.s3.bucket}
+    region:
+      static: ${cloud.aws.region.static}
+  stack:
+    auto: false

--- a/src/test/java/pie/tomato/tomatomarket/application/unit/ImageServiceTest.java
+++ b/src/test/java/pie/tomato/tomatomarket/application/unit/ImageServiceTest.java
@@ -1,0 +1,45 @@
+package pie.tomato.tomatomarket.application.unit;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.transaction.annotation.Transactional;
+
+import pie.tomato.tomatomarket.application.ImageService;
+import pie.tomato.tomatomarket.application.ImageUploader;
+import pie.tomato.tomatomarket.domain.ImageFile;
+
+@Transactional
+@SpringBootTest
+class ImageServiceTest {
+
+	@InjectMocks
+	private ImageService imageService;
+	@Mock
+	private ImageUploader imageUploader;
+
+	@DisplayName("이미지 파일이 주어지면 업로드에 성공한다.")
+	@Test
+	void imageUpload() throws IOException {
+		// given
+		MockMultipartFile mockMultipartFile = new MockMultipartFile(
+			"test-image", "test.png",
+			MediaType.IMAGE_PNG_VALUE, "imageBytes".getBytes(StandardCharsets.UTF_8));
+
+		given(imageUploader.uploadImageToS3(any(ImageFile.class))).willReturn("url");
+
+		// when & then
+		assertThatCode(() -> imageService.uploadImageToS3(mockMultipartFile))
+			.doesNotThrowAnyException();
+	}
+}

--- a/src/test/java/pie/tomato/tomatomarket/application/unit/ImageServiceTest.java
+++ b/src/test/java/pie/tomato/tomatomarket/application/unit/ImageServiceTest.java
@@ -3,14 +3,14 @@ package pie.tomato.tomatomarket.application.unit;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,7 +20,7 @@ import pie.tomato.tomatomarket.application.ImageUploader;
 import pie.tomato.tomatomarket.domain.ImageFile;
 
 @Transactional
-@SpringBootTest
+@ExtendWith(MockitoExtension.class)
 class ImageServiceTest {
 
 	@InjectMocks
@@ -30,7 +30,7 @@ class ImageServiceTest {
 
 	@DisplayName("이미지 파일이 주어지면 업로드에 성공한다.")
 	@Test
-	void imageUpload() throws IOException {
+	void imageUpload() {
 		// given
 		MockMultipartFile mockMultipartFile = new MockMultipartFile(
 			"test-image", "test.png",


### PR DESCRIPTION
## Issues
- #10 

## What is this PR? 👓
- 이미지 업로드 기능을 구현했습니다.
- 이미지 업로드 기능을 테스트했습니다.

##  📖 다시 한번 정리하기
- `S3Properties` : .yml 파일에서 읽어온 accessKey, secretKey, bucket, region을 가지고 있음
- `S3Config`: S3에 이미지를 올리기 위해 사용되는 `AmazonS3Client`를 `bean`으로 등록
- `ImageFile` : multipartfile자체를 s3에 올리는게 아닌 이미지 파일로 변환시켜 s3에 저장해야 하기 때문에 multipartfile에 담긴 필요한 정보들만 분리 해 도메인 객체로 저장. 
  -  s3에 저장 시킬때 이미지의 파일 이름이 중복되면 안되므로 randomUUID를 생성 해 fileName에 붙여넣음
- `ImageService`: mulitpartfile로 들어온 데이터를 ImageFile 객체로 변환 시켜주고 imageUploader에게 업로딩 역할을 던져줌.
- `ImageUploader`: 이미지를 업로딩 하는 역할만 한다.