### PR TITLE
[feat] @AuthPrincipal 애노테이션으로 유저 정보 가져오기

### DIFF
--- a/src/main/java/pie/tomato/tomatomarket/application/AuthService.java
+++ b/src/main/java/pie/tomato/tomatomarket/application/AuthService.java
@@ -6,7 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import pie.tomato.tomatomarket.application.oauth.KakaoClient;
 import pie.tomato.tomatomarket.domain.Member;
-import pie.tomato.tomatomarket.domain.oauth.OAuthUser;
+import pie.tomato.tomatomarket.domain.OAuthUser;
 import pie.tomato.tomatomarket.exception.BadRequestException;
 import pie.tomato.tomatomarket.exception.ErrorCode;
 import pie.tomato.tomatomarket.exception.NotFoundException;

--- a/src/main/java/pie/tomato/tomatomarket/application/oauth/KakaoClient.java
+++ b/src/main/java/pie/tomato/tomatomarket/application/oauth/KakaoClient.java
@@ -11,7 +11,7 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
 import lombok.RequiredArgsConstructor;
-import pie.tomato.tomatomarket.domain.oauth.OAuthUser;
+import pie.tomato.tomatomarket.domain.OAuthUser;
 import pie.tomato.tomatomarket.infrastructure.config.properties.OauthProperties;
 
 @Component

--- a/src/main/java/pie/tomato/tomatomarket/domain/OAuthUser.java
+++ b/src/main/java/pie/tomato/tomatomarket/domain/OAuthUser.java
@@ -1,4 +1,4 @@
-package pie.tomato.tomatomarket.domain.oauth;
+package pie.tomato.tomatomarket.domain;
 
 import java.util.Map;
 import java.util.UUID;

--- a/src/main/java/pie/tomato/tomatomarket/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/pie/tomato/tomatomarket/exception/handler/GlobalExceptionHandler.java
@@ -7,6 +7,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import pie.tomato.tomatomarket.exception.BadRequestException;
 import pie.tomato.tomatomarket.exception.ErrorResponse;
+import pie.tomato.tomatomarket.exception.InternalServerException;
+import pie.tomato.tomatomarket.exception.NotFoundException;
 import pie.tomato.tomatomarket.exception.UnAuthorizedException;
 
 @RestControllerAdvice
@@ -22,5 +24,17 @@ public class GlobalExceptionHandler {
 	public ResponseEntity<ErrorResponse> handleUnAuthorizedException(UnAuthorizedException e) {
 		return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
 			.body(new ErrorResponse(401, e.getMessage()));
+	}
+
+	@ExceptionHandler(NotFoundException.class)
+	public ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException e) {
+		return ResponseEntity.status(HttpStatus.NOT_FOUND)
+			.body(new ErrorResponse(404, e.getMessage()));
+	}
+
+	@ExceptionHandler(InternalServerException.class)
+	public ResponseEntity<ErrorResponse> handleInternalServerException(InternalServerException e) {
+		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+			.body(new ErrorResponse(500, e.getMessage()));
 	}
 }

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/config/FilterConfig.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/config/FilterConfig.java
@@ -1,0 +1,37 @@
+package pie.tomato.tomatomarket.infrastructure.config;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import lombok.RequiredArgsConstructor;
+import pie.tomato.tomatomarket.infrastructure.config.jwt.JwtProvider;
+import pie.tomato.tomatomarket.presentation.filter.AuthExceptionHandlerFilter;
+import pie.tomato.tomatomarket.presentation.filter.JwtFilter;
+import pie.tomato.tomatomarket.presentation.support.AuthenticationContext;
+
+@Configuration
+@RequiredArgsConstructor
+public class FilterConfig {
+
+	private final JwtProvider jwtProvider;
+	private final AuthenticationContext authenticationContext;
+
+	@Bean
+	public FilterRegistrationBean<JwtFilter> jwtFilter() {
+		FilterRegistrationBean<JwtFilter> jwtFilter = new FilterRegistrationBean<>();
+		jwtFilter.setFilter(new JwtFilter(jwtProvider, authenticationContext));
+		jwtFilter.addUrlPatterns("/api/*");
+		jwtFilter.setOrder(2);
+		return jwtFilter;
+	}
+
+	@Bean
+	public FilterRegistrationBean<AuthExceptionHandlerFilter> authExceptionHandlerFilter() {
+		FilterRegistrationBean<AuthExceptionHandlerFilter> authExceptionHandlerFilter = new FilterRegistrationBean<>();
+		authExceptionHandlerFilter.setFilter(new AuthExceptionHandlerFilter());
+		authExceptionHandlerFilter.addUrlPatterns("/api/*");
+		authExceptionHandlerFilter.setOrder(1);
+		return authExceptionHandlerFilter;
+	}
+}

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/config/PropertiesConfig.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/config/PropertiesConfig.java
@@ -1,4 +1,4 @@
-package pie.tomato.config;
+package pie.tomato.tomatomarket.infrastructure.config;
 
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/config/WebConfig.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/config/WebConfig.java
@@ -1,0 +1,22 @@
+package pie.tomato.tomatomarket.infrastructure.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import lombok.RequiredArgsConstructor;
+import pie.tomato.tomatomarket.presentation.support.AuthPrincipalArgumentResolver;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+	private final AuthPrincipalArgumentResolver authPrincipalArgumentResolver;
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+		resolvers.add(authPrincipalArgumentResolver);
+	}
+}

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/config/jwt/JwtProvider.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/config/jwt/JwtProvider.java
@@ -8,6 +8,7 @@ import javax.crypto.SecretKey;
 
 import org.springframework.stereotype.Component;
 
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
@@ -16,6 +17,7 @@ import io.jsonwebtoken.security.Keys;
 import pie.tomato.tomatomarket.exception.ErrorCode;
 import pie.tomato.tomatomarket.exception.UnAuthorizedException;
 import pie.tomato.tomatomarket.infrastructure.config.properties.JwtProperties;
+import pie.tomato.tomatomarket.presentation.support.Principal;
 
 @Component
 public class JwtProvider {
@@ -51,5 +53,15 @@ public class JwtProvider {
 		} catch (JwtException e) {
 			throw new UnAuthorizedException(ErrorCode.INVALID_TOKEN);
 		}
+	}
+
+	public Principal extractPrincipal(final String token) {
+		final Claims claims = Jwts.parserBuilder()
+			.setSigningKey(secretKey)
+			.build()
+			.parseClaimsJws(token)
+			.getBody();
+
+		return Principal.from(claims);
 	}
 }

--- a/src/main/java/pie/tomato/tomatomarket/presentation/filter/AuthExceptionHandlerFilter.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/filter/AuthExceptionHandlerFilter.java
@@ -1,0 +1,32 @@
+package pie.tomato.tomatomarket.presentation.filter;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import lombok.RequiredArgsConstructor;
+import pie.tomato.tomatomarket.exception.UnAuthorizedException;
+
+@RequiredArgsConstructor
+public class AuthExceptionHandlerFilter extends OncePerRequestFilter {
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+		try {
+			filterChain.doFilter(request, response);
+		} catch (UnAuthorizedException e) {
+			setErrorResponse(response);
+		}
+	}
+
+	private void setErrorResponse(HttpServletResponse response) {
+		response.setStatus(HttpStatus.UNAUTHORIZED.value());
+	}
+}

--- a/src/main/java/pie/tomato/tomatomarket/presentation/filter/JwtFilter.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/filter/JwtFilter.java
@@ -18,6 +18,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import pie.tomato.tomatomarket.exception.ErrorCode;
 import pie.tomato.tomatomarket.exception.UnAuthorizedException;
 import pie.tomato.tomatomarket.infrastructure.config.jwt.JwtProvider;
+import pie.tomato.tomatomarket.presentation.support.AuthenticationContext;
 
 public class JwtFilter extends OncePerRequestFilter {
 
@@ -27,9 +28,11 @@ public class JwtFilter extends OncePerRequestFilter {
 	private final List<String> excludeUrlPatterns = List.of("/api/auth/**");
 
 	private final JwtProvider jwtProvider;
+	private final AuthenticationContext authenticationContext;
 
-	public JwtFilter(JwtProvider jwtProvider) {
+	public JwtFilter(JwtProvider jwtProvider, AuthenticationContext authenticationContext) {
 		this.jwtProvider = jwtProvider;
+		this.authenticationContext = authenticationContext;
 	}
 
 	@Override
@@ -49,6 +52,7 @@ public class JwtFilter extends OncePerRequestFilter {
 		String token = extractJwt(request)
 			.orElseThrow(() -> new UnAuthorizedException(ErrorCode.INVALID_TOKEN));
 		jwtProvider.validateToken(token);
+		authenticationContext.setPrincipal(jwtProvider.extractPrincipal(token));
 
 		filterChain.doFilter(request, response);
 	}

--- a/src/main/java/pie/tomato/tomatomarket/presentation/support/AuthPrincipal.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/support/AuthPrincipal.java
@@ -1,0 +1,11 @@
+package pie.tomato.tomatomarket.presentation.support;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthPrincipal {
+}

--- a/src/main/java/pie/tomato/tomatomarket/presentation/support/AuthPrincipalArgumentResolver.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/support/AuthPrincipalArgumentResolver.java
@@ -18,7 +18,7 @@ public class AuthPrincipalArgumentResolver implements HandlerMethodArgumentResol
 	@Override
 	public boolean supportsParameter(MethodParameter parameter) {
 		return parameter.hasParameterAnnotation(AuthPrincipal.class)
-			&& parameter.getParameterType().equals(Principal.class);
+			&& parameter.getParameterType().isAssignableFrom(Principal.class);
 	}
 
 	@Override

--- a/src/main/java/pie/tomato/tomatomarket/presentation/support/AuthPrincipalArgumentResolver.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/support/AuthPrincipalArgumentResolver.java
@@ -1,0 +1,29 @@
+package pie.tomato.tomatomarket.presentation.support;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AuthPrincipalArgumentResolver implements HandlerMethodArgumentResolver {
+
+	private final AuthenticationContext authenticationContext;
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return parameter.hasParameterAnnotation(AuthPrincipal.class)
+			&& parameter.getParameterType().equals(Principal.class);
+	}
+
+	@Override
+	public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+		NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+		return authenticationContext.getPrincipal();
+	}
+}

--- a/src/main/java/pie/tomato/tomatomarket/presentation/support/AuthenticationContext.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/support/AuthenticationContext.java
@@ -1,0 +1,18 @@
+package pie.tomato.tomatomarket.presentation.support;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
+
+import lombok.Getter;
+
+@Getter
+@Component
+@RequestScope
+public class AuthenticationContext {
+
+	private Principal principal;
+	
+	public void setPrincipal(Principal principal) {
+		this.principal = principal;
+	}
+}

--- a/src/main/java/pie/tomato/tomatomarket/presentation/support/Principal.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/support/Principal.java
@@ -5,6 +5,8 @@ import java.util.Optional;
 import io.jsonwebtoken.Claims;
 import lombok.Builder;
 import lombok.Getter;
+import pie.tomato.tomatomarket.exception.ErrorCode;
+import pie.tomato.tomatomarket.exception.UnAuthorizedException;
 
 @Getter
 @Builder
@@ -13,18 +15,24 @@ public class Principal {
 	private Long memberId;
 	private String nickname;
 	private String email;
-	private String profile;
 
 	public static Principal from(Claims claims) {
 		PrincipalBuilder principal = Principal.builder();
 		Optional.ofNullable(claims.get("memberId"))
-			.ifPresent(memberId -> principal.memberId(Long.valueOf(memberId.toString())));
+			.ifPresentOrElse(memberId -> principal.memberId(Long.valueOf(memberId.toString())),
+				() -> {
+					throw new UnAuthorizedException(ErrorCode.INVALID_TOKEN);
+				});
 		Optional.ofNullable(claims.get("email"))
-			.ifPresent(email -> principal.email((String)email));
+			.ifPresentOrElse(email -> principal.email((String)email),
+				() -> {
+					throw new UnAuthorizedException(ErrorCode.INVALID_TOKEN);
+				});
 		Optional.ofNullable(claims.get("nickname"))
-			.ifPresent(nickname -> principal.nickname((String)nickname));
-		Optional.ofNullable(claims.get("profile"))
-			.ifPresent(profile -> principal.profile((String)profile));
+			.ifPresentOrElse(nickname -> principal.nickname((String)nickname),
+				() -> {
+					throw new UnAuthorizedException(ErrorCode.INVALID_TOKEN);
+				});
 		return principal.build();
 	}
 }

--- a/src/main/java/pie/tomato/tomatomarket/presentation/support/Principal.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/support/Principal.java
@@ -1,0 +1,30 @@
+package pie.tomato.tomatomarket.presentation.support;
+
+import java.util.Optional;
+
+import io.jsonwebtoken.Claims;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class Principal {
+
+	private Long memberId;
+	private String nickname;
+	private String email;
+	private String profile;
+
+	public static Principal from(Claims claims) {
+		PrincipalBuilder principal = Principal.builder();
+		Optional.ofNullable(claims.get("memberId"))
+			.ifPresent(memberId -> principal.memberId(Long.valueOf(memberId.toString())));
+		Optional.ofNullable(claims.get("email"))
+			.ifPresent(email -> principal.email((String)email));
+		Optional.ofNullable(claims.get("nickname"))
+			.ifPresent(nickname -> principal.nickname((String)nickname));
+		Optional.ofNullable(claims.get("profile"))
+			.ifPresent(profile -> principal.profile((String)profile));
+		return principal.build();
+	}
+}

--- a/src/test/java/pie/tomato/tomatomarket/application/unit/AuthServiceTest.java
+++ b/src/test/java/pie/tomato/tomatomarket/application/unit/AuthServiceTest.java
@@ -14,7 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import pie.tomato.tomatomarket.application.AuthService;
 import pie.tomato.tomatomarket.application.oauth.KakaoClient;
-import pie.tomato.tomatomarket.domain.oauth.OAuthUser;
+import pie.tomato.tomatomarket.domain.OAuthUser;
 import pie.tomato.tomatomarket.exception.BadRequestException;
 import pie.tomato.tomatomarket.exception.ErrorCode;
 import pie.tomato.tomatomarket.infrastructure.persistence.MemberRepository;
@@ -87,7 +87,7 @@ class AuthServiceTest {
 				"nickname", "pie123",
 				"profile_image_url", "pie/image.jpg"
 			)));
-		
+
 		OAuthUser oAuthUser = OAuthUser.from(response);
 
 		given(kakaoClient.getAccessToken(anyString())).willReturn("abc.abc.abc");


### PR DESCRIPTION
## Issues
- #12 

## What is this PR? 👓
- `@AuthPrincipal` 애노테이션으로 유저 정보를 가져오는 기능을 구현했습니다.

## Key Changes 🔑
- 사용자가 들고있는 토큰을 이용해 사용자 정보를 가져오는 기능을 구현했습니다.

## 📖 공부하면서 배웠던 것
- jwt 토큰을 이용해 사용자의 정보를  추출하고 추출된 사용자의 정보를 저장하기 위해 `AuthenticationContext`를 만들었습니다. `AuthenticationContext`에 `@RequestScope`애노테이션을 달아 모든 request마다 `AuthenticationContext`를 생성할 수 있도록 했습니다. 이제 저장한 정보를 애노테이션을 통해 쉽게 추출하기 위해 `ArgumentResolver`를 생성 후 `ArgumentResolver`를 동작시키기 위해서 `webConfig`클래스에 `addArgumentResolvers` 메서드를 오버라이딩해 작성했습니다.
- 마찬가지로 filter도 생성은 해놨지만 빈으로 등록하지 않아서 `filterConfig`클래스를 만들었습니다. config를 통해 작성한 filter를 bean으로 등록해두고 filter의 순서를 정하고 어떤 api에 작동할 것인지 세부적인 내용을 셋팅해두었습니다.

### 📌 ArgumentResolver
Argument Resolver는 어떠한 요청이 컨트롤러에 들어왔을 때, 요청에 들어온 값으로부터 원하는 객체를 만들어 내는 일을 간접적으로 해줄 수 있습니다. 하여 custom한 argumentResolver를 사용하기 위해서는 HandlerMethodArgumentResolver를 구현함으로써 사용할 수 있습니다. 그리고 이 인터페이스는 아래 두 메소드를 구현하도록 명시하고 있습니다
- `supportsParameter` 메서드
  - ArgumentResolver가 실행되길 원하는 Parameter의 앞에 특정 어노테이션을 생성해 붙여줍니다. `supportsParameter()` 메서드는 요청받은 메서드의 인자에 원하는 어노테이션이 붙어있는지 확인하고 원하는 어노테이션을 포함하고 있으면 true를 반환합니다. (참고로 여기에 원하는 조건을 설정해도 무방합니다.)
- `resolveArgument` 메서드
  - supportsParameter에서 true를 받은 경우,  parameter가 원하는 형태로 정보를 바인딩하여 반환하는 메서드입니다. supportsParameter에서 true를 받은 경우에만 실행이 됩니다. 

 