### PR TITLE
[feat] 상품 상태 변경

### DIFF
--- a/src/main/java/pie/tomato/tomatomarket/application/ItemService.java
+++ b/src/main/java/pie/tomato/tomatomarket/application/ItemService.java
@@ -38,7 +38,7 @@ public class ItemService {
 		ItemStatus itemStatus = ItemStatus.from(itemRegisterRequest.getStatus());
 		String thumbnailUrl = imageService.uploadImageToS3(thumbnail);
 
-		Member member = new Member(principal.getMemberId());
+		Member member = memberRepository.getReferenceById(principal.getMemberId());
 		Item item = itemRepository.save(itemRegisterRequest.toEntity(member, thumbnailUrl, itemStatus));
 
 		if (itemImages != null) {

--- a/src/main/java/pie/tomato/tomatomarket/application/image/ImageService.java
+++ b/src/main/java/pie/tomato/tomatomarket/application/image/ImageService.java
@@ -1,4 +1,4 @@
-package pie.tomato.tomatomarket.application;
+package pie.tomato.tomatomarket.application.image;
 
 import java.util.List;
 

--- a/src/main/java/pie/tomato/tomatomarket/application/image/ImageUploader.java
+++ b/src/main/java/pie/tomato/tomatomarket/application/image/ImageUploader.java
@@ -1,4 +1,4 @@
-package pie.tomato.tomatomarket.application;
+package pie.tomato.tomatomarket.application.image;
 
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;

--- a/src/main/java/pie/tomato/tomatomarket/application/item/ItemService.java
+++ b/src/main/java/pie/tomato/tomatomarket/application/item/ItemService.java
@@ -1,4 +1,4 @@
-package pie.tomato.tomatomarket.application;
+package pie.tomato.tomatomarket.application.item;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import lombok.RequiredArgsConstructor;
+import pie.tomato.tomatomarket.application.image.ImageService;
 import pie.tomato.tomatomarket.domain.Image;
 import pie.tomato.tomatomarket.domain.Item;
 import pie.tomato.tomatomarket.domain.ItemStatus;
@@ -18,8 +19,8 @@ import pie.tomato.tomatomarket.exception.NotFoundException;
 import pie.tomato.tomatomarket.infrastructure.persistence.ImageRepository;
 import pie.tomato.tomatomarket.infrastructure.persistence.ItemRepository;
 import pie.tomato.tomatomarket.infrastructure.persistence.MemberRepository;
-import pie.tomato.tomatomarket.presentation.request.ItemRegisterRequest;
-import pie.tomato.tomatomarket.presentation.request.ItemStatusModifyRequest;
+import pie.tomato.tomatomarket.presentation.request.item.ItemRegisterRequest;
+import pie.tomato.tomatomarket.presentation.request.item.ItemStatusModifyRequest;
 import pie.tomato.tomatomarket.presentation.support.Principal;
 
 @Service

--- a/src/main/java/pie/tomato/tomatomarket/application/item/ItemService.java
+++ b/src/main/java/pie/tomato/tomatomarket/application/item/ItemService.java
@@ -16,9 +16,9 @@ import pie.tomato.tomatomarket.domain.Member;
 import pie.tomato.tomatomarket.exception.BadRequestException;
 import pie.tomato.tomatomarket.exception.ErrorCode;
 import pie.tomato.tomatomarket.exception.NotFoundException;
-import pie.tomato.tomatomarket.infrastructure.persistence.ImageRepository;
 import pie.tomato.tomatomarket.infrastructure.persistence.ItemRepository;
 import pie.tomato.tomatomarket.infrastructure.persistence.MemberRepository;
+import pie.tomato.tomatomarket.infrastructure.persistence.image.ImageRepository;
 import pie.tomato.tomatomarket.presentation.request.item.ItemRegisterRequest;
 import pie.tomato.tomatomarket.presentation.request.item.ItemStatusModifyRequest;
 import pie.tomato.tomatomarket.presentation.support.Principal;
@@ -44,9 +44,10 @@ public class ItemService {
 
 		if (itemImages != null) {
 			List<String> images = imageService.uploadImagesToS3(itemImages);
-			imageRepository.saveAll(images.stream()
-				.map(url -> Image.of(url, item))
-				.collect(Collectors.toList()));
+			List<Image> imageList = images.stream()
+				.map(url -> Image.toEntity(url, item))
+				.collect(Collectors.toList());
+			imageRepository.saveAllImages(imageList);
 		}
 	}
 

--- a/src/main/java/pie/tomato/tomatomarket/application/member/MemberService.java
+++ b/src/main/java/pie/tomato/tomatomarket/application/member/MemberService.java
@@ -1,4 +1,4 @@
-package pie.tomato.tomatomarket.application;
+package pie.tomato.tomatomarket.application.member;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/pie/tomato/tomatomarket/application/oauth/AuthService.java
+++ b/src/main/java/pie/tomato/tomatomarket/application/oauth/AuthService.java
@@ -1,10 +1,9 @@
-package pie.tomato.tomatomarket.application;
+package pie.tomato.tomatomarket.application.oauth;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
-import pie.tomato.tomatomarket.application.oauth.KakaoClient;
 import pie.tomato.tomatomarket.domain.Member;
 import pie.tomato.tomatomarket.domain.OAuthUser;
 import pie.tomato.tomatomarket.exception.BadRequestException;

--- a/src/main/java/pie/tomato/tomatomarket/domain/Image.java
+++ b/src/main/java/pie/tomato/tomatomarket/domain/Image.java
@@ -10,10 +10,12 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = PROTECTED)
+@Getter
 public class Image {
 
 	@Id
@@ -30,7 +32,7 @@ public class Image {
 		this.item = item;
 	}
 
-	public static Image of(String imageUrl, Item item) {
+	public static Image toEntity(String imageUrl, Item item) {
 		return new Image(imageUrl, item);
 	}
 }

--- a/src/main/java/pie/tomato/tomatomarket/domain/Item.java
+++ b/src/main/java/pie/tomato/tomatomarket/domain/Item.java
@@ -7,6 +7,8 @@ import static lombok.AccessLevel.*;
 import java.time.LocalDateTime;
 
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
@@ -28,6 +30,7 @@ public class Item {
 	private String content;
 	private Long price;
 	private String thumbnail;
+	@Enumerated(EnumType.STRING)
 	private ItemStatus status;
 	private String region;
 	private Long chatCount;
@@ -59,5 +62,9 @@ public class Item {
 		this.createdAt = createdAt;
 		this.member = member;
 		this.category = category;
+	}
+
+	public void changeStatus(ItemStatus status) {
+		this.status = status;
 	}
 }

--- a/src/main/java/pie/tomato/tomatomarket/domain/Member.java
+++ b/src/main/java/pie/tomato/tomatomarket/domain/Member.java
@@ -22,10 +22,6 @@ public class Member {
 	private String email;
 	private String profile;
 
-	public Member(Long id) {
-		this.id = id;
-	}
-
 	public Member(String nickname, String email, String profile) {
 		this.nickname = nickname;
 		this.email = email;

--- a/src/main/java/pie/tomato/tomatomarket/exception/ErrorCode.java
+++ b/src/main/java/pie/tomato/tomatomarket/exception/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
 
 	// Item
 	INVALID_STATUS(HttpStatus.BAD_REQUEST, "상태는 판매중, 예약중, 판매완료만 들어올 수 있습니다."),
+	ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."),
 
 	// Auth
 	NOT_LOGIN(HttpStatus.UNAUTHORIZED, "로그인 상태가 아닙니다.");

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/ImageRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/ImageRepository.java
@@ -1,8 +1,0 @@
-package pie.tomato.tomatomarket.infrastructure.persistence;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import pie.tomato.tomatomarket.domain.Image;
-
-public interface ImageRepository extends JpaRepository<Image, Long> {
-}

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/MemberRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/MemberRepository.java
@@ -14,4 +14,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
 	boolean existsByNickname(String nickname);
 
+	boolean existsMemberById(Long memberId);
+
 }

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/MemberRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/MemberRepository.java
@@ -15,5 +15,4 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 	boolean existsByNickname(String nickname);
 
 	boolean existsMemberById(Long memberId);
-
 }

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/image/ImageRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/image/ImageRepository.java
@@ -1,0 +1,8 @@
+package pie.tomato.tomatomarket.infrastructure.persistence.image;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import pie.tomato.tomatomarket.domain.Image;
+
+public interface ImageRepository extends JpaRepository<Image, Long>, ImageRepositoryCustom {
+}

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/image/ImageRepositoryCustom.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/image/ImageRepositoryCustom.java
@@ -1,0 +1,10 @@
+package pie.tomato.tomatomarket.infrastructure.persistence.image;
+
+import java.util.List;
+
+import pie.tomato.tomatomarket.domain.Image;
+
+public interface ImageRepositoryCustom {
+
+	void saveAllImages(List<Image> itemImages);
+}

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/image/ImageRepositoryImpl.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/image/ImageRepositoryImpl.java
@@ -1,0 +1,29 @@
+package pie.tomato.tomatomarket.infrastructure.persistence.image;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import lombok.RequiredArgsConstructor;
+import pie.tomato.tomatomarket.domain.Image;
+
+@RequiredArgsConstructor
+public class ImageRepositoryImpl implements ImageRepositoryCustom {
+
+	private final NamedParameterJdbcTemplate jdbcTemplate;
+
+	@Override
+	public void saveAllImages(List<Image> itemImages) {
+		String sql = "INSERT INTO image "
+			+ "(image_url, item_id) VALUES (:imageUrl, :itemId)";
+		MapSqlParameterSource[] params = itemImages.stream()
+			.map(itemImage -> new MapSqlParameterSource()
+				.addValue("imageUrl", itemImage.getImageUrl())
+				.addValue("itemId", itemImage.getItem().getId()))
+			.collect(Collectors.toList())
+			.toArray(MapSqlParameterSource[]::new);
+		jdbcTemplate.batchUpdate(sql, params);
+	}
+}

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/image/ImageRepositoryImpl.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/image/ImageRepositoryImpl.java
@@ -18,12 +18,14 @@ public class ImageRepositoryImpl implements ImageRepositoryCustom {
 	public void saveAllImages(List<Image> itemImages) {
 		String sql = "INSERT INTO image "
 			+ "(image_url, item_id) VALUES (:imageUrl, :itemId)";
+
 		MapSqlParameterSource[] params = itemImages.stream()
 			.map(itemImage -> new MapSqlParameterSource()
 				.addValue("imageUrl", itemImage.getImageUrl())
 				.addValue("itemId", itemImage.getItem().getId()))
 			.collect(Collectors.toList())
 			.toArray(MapSqlParameterSource[]::new);
+		
 		jdbcTemplate.batchUpdate(sql, params);
 	}
 }

--- a/src/main/java/pie/tomato/tomatomarket/presentation/AuthController.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/AuthController.java
@@ -10,8 +10,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
-import pie.tomato.tomatomarket.application.AuthService;
-import pie.tomato.tomatomarket.presentation.response.LoginResponse;
+import pie.tomato.tomatomarket.application.oauth.AuthService;
+import pie.tomato.tomatomarket.presentation.response.oauth.LoginResponse;
 
 @RequiredArgsConstructor
 @RestController

--- a/src/main/java/pie/tomato/tomatomarket/presentation/ItemController.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/ItemController.java
@@ -5,7 +5,10 @@ import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,6 +17,7 @@ import org.springframework.web.multipart.MultipartFile;
 import lombok.RequiredArgsConstructor;
 import pie.tomato.tomatomarket.application.ItemService;
 import pie.tomato.tomatomarket.presentation.request.ItemRegisterRequest;
+import pie.tomato.tomatomarket.presentation.request.ItemStatusModifyRequest;
 import pie.tomato.tomatomarket.presentation.support.AuthPrincipal;
 import pie.tomato.tomatomarket.presentation.support.Principal;
 
@@ -31,5 +35,12 @@ public class ItemController {
 		@AuthPrincipal Principal principal) {
 		itemService.register(itemRegisterRequest, thumbnail, itemImages, principal);
 		return ResponseEntity.status(HttpStatus.CREATED).build();
+	}
+
+	@PutMapping("/{itemId}/status")
+	public ResponseEntity<Void> modifyStatus(@PathVariable Long itemId, @AuthPrincipal Principal principal
+		, @RequestBody ItemStatusModifyRequest request) {
+		itemService.modifyStatus(itemId, principal, request);
+		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/pie/tomato/tomatomarket/presentation/ItemController.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/ItemController.java
@@ -15,9 +15,9 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import lombok.RequiredArgsConstructor;
-import pie.tomato.tomatomarket.application.ItemService;
-import pie.tomato.tomatomarket.presentation.request.ItemRegisterRequest;
-import pie.tomato.tomatomarket.presentation.request.ItemStatusModifyRequest;
+import pie.tomato.tomatomarket.application.item.ItemService;
+import pie.tomato.tomatomarket.presentation.request.item.ItemRegisterRequest;
+import pie.tomato.tomatomarket.presentation.request.item.ItemStatusModifyRequest;
 import pie.tomato.tomatomarket.presentation.support.AuthPrincipal;
 import pie.tomato.tomatomarket.presentation.support.Principal;
 

--- a/src/main/java/pie/tomato/tomatomarket/presentation/ItemController.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/ItemController.java
@@ -38,8 +38,9 @@ public class ItemController {
 	}
 
 	@PutMapping("/{itemId}/status")
-	public ResponseEntity<Void> modifyStatus(@PathVariable Long itemId, @AuthPrincipal Principal principal
-		, @RequestBody ItemStatusModifyRequest request) {
+	public ResponseEntity<Void> modifyStatus(@PathVariable Long itemId,
+		@AuthPrincipal Principal principal,
+		@RequestBody ItemStatusModifyRequest request) {
 		itemService.modifyStatus(itemId, principal, request);
 		return ResponseEntity.ok().build();
 	}

--- a/src/main/java/pie/tomato/tomatomarket/presentation/MemberController.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/MemberController.java
@@ -8,8 +8,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
-import pie.tomato.tomatomarket.application.MemberService;
-import pie.tomato.tomatomarket.presentation.request.NicknameModifyRequest;
+import pie.tomato.tomatomarket.application.member.MemberService;
+import pie.tomato.tomatomarket.presentation.request.member.NicknameModifyRequest;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/pie/tomato/tomatomarket/presentation/request/ItemStatusModifyRequest.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/request/ItemStatusModifyRequest.java
@@ -1,0 +1,13 @@
+package pie.tomato.tomatomarket.presentation.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ItemStatusModifyRequest {
+
+	private String status;
+}

--- a/src/main/java/pie/tomato/tomatomarket/presentation/request/item/ItemRegisterRequest.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/request/item/ItemRegisterRequest.java
@@ -1,4 +1,4 @@
-package pie.tomato.tomatomarket.presentation.request;
+package pie.tomato.tomatomarket.presentation.request.item;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/pie/tomato/tomatomarket/presentation/request/item/ItemStatusModifyRequest.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/request/item/ItemStatusModifyRequest.java
@@ -1,4 +1,4 @@
-package pie.tomato.tomatomarket.presentation.request;
+package pie.tomato.tomatomarket.presentation.request.item;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/pie/tomato/tomatomarket/presentation/request/member/NicknameModifyRequest.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/request/member/NicknameModifyRequest.java
@@ -1,4 +1,4 @@
-package pie.tomato.tomatomarket.presentation.request;
+package pie.tomato.tomatomarket.presentation.request.member;
 
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/pie/tomato/tomatomarket/presentation/response/oauth/LoginResponse.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/response/oauth/LoginResponse.java
@@ -1,4 +1,4 @@
-package pie.tomato.tomatomarket.presentation.response;
+package pie.tomato.tomatomarket.presentation.response.oauth;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/test/java/pie/tomato/tomatomarket/application/ItemServiceTest.java
+++ b/src/test/java/pie/tomato/tomatomarket/application/ItemServiceTest.java
@@ -102,11 +102,12 @@ class ItemServiceTest {
 			.memberId(member.getId())
 			.build();
 		ItemStatusModifyRequest request = new ItemStatusModifyRequest("예약중");
+		
 		// when
 		itemService.modifyStatus(item.getId(), principal, request);
+
 		// then
 		Item findItem = supportRepository.findById(item.getId(), Item.class);
 		assertThat(findItem.getStatus()).isEqualTo(ItemStatus.RESERVED);
-
 	}
 }

--- a/src/test/java/pie/tomato/tomatomarket/application/ItemServiceTest.java
+++ b/src/test/java/pie/tomato/tomatomarket/application/ItemServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -18,8 +19,10 @@ import org.springframework.transaction.annotation.Transactional;
 import pie.tomato.tomatomarket.domain.Category;
 import pie.tomato.tomatomarket.domain.ImageFile;
 import pie.tomato.tomatomarket.domain.Item;
+import pie.tomato.tomatomarket.domain.ItemStatus;
 import pie.tomato.tomatomarket.domain.Member;
 import pie.tomato.tomatomarket.presentation.request.ItemRegisterRequest;
+import pie.tomato.tomatomarket.presentation.request.ItemStatusModifyRequest;
 import pie.tomato.tomatomarket.presentation.support.Principal;
 import pie.tomato.tomatomarket.support.SupportRepository;
 
@@ -80,5 +83,28 @@ class ItemServiceTest {
 			.hasFieldOrProperty("viewCount")
 			.hasFieldOrProperty("wishCount")
 			.hasFieldOrProperty("createdAt");
+	}
+
+	@DisplayName("상품 상태 수정에 성공한다.")
+	@Test
+	void modifyItemStatus() {
+		// given
+		Member member = supportRepository.save(new Member("파이", "123@123", "profile"));
+		Category category = supportRepository.save(new Category("잡화", "categoryImage"));
+		Item item = supportRepository.save(new Item("머리끈", "머리끈 100개 팝니다.", 3000L, "thumbnail", ItemStatus.ON_SALE,
+			"역삼1동", 0L, 0L, 0L, LocalDateTime.now(), member, category));
+
+		Principal principal = Principal.builder()
+			.nickname(member.getNickname())
+			.email(member.getEmail())
+			.memberId(member.getId())
+			.build();
+		ItemStatusModifyRequest request = new ItemStatusModifyRequest("예약중");
+		// when
+		itemService.modifyStatus(item.getId(), principal, request);
+		// then
+		Item findItem = supportRepository.findById(item.getId(), Item.class);
+		assertThat(findItem.getStatus()).isEqualTo(ItemStatus.RESERVED);
+
 	}
 }

--- a/src/test/java/pie/tomato/tomatomarket/application/ItemServiceTest.java
+++ b/src/test/java/pie/tomato/tomatomarket/application/ItemServiceTest.java
@@ -16,13 +16,15 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.transaction.annotation.Transactional;
 
+import pie.tomato.tomatomarket.application.image.ImageUploader;
+import pie.tomato.tomatomarket.application.item.ItemService;
 import pie.tomato.tomatomarket.domain.Category;
 import pie.tomato.tomatomarket.domain.ImageFile;
 import pie.tomato.tomatomarket.domain.Item;
 import pie.tomato.tomatomarket.domain.ItemStatus;
 import pie.tomato.tomatomarket.domain.Member;
-import pie.tomato.tomatomarket.presentation.request.ItemRegisterRequest;
-import pie.tomato.tomatomarket.presentation.request.ItemStatusModifyRequest;
+import pie.tomato.tomatomarket.presentation.request.item.ItemRegisterRequest;
+import pie.tomato.tomatomarket.presentation.request.item.ItemStatusModifyRequest;
 import pie.tomato.tomatomarket.presentation.support.Principal;
 import pie.tomato.tomatomarket.support.SupportRepository;
 

--- a/src/test/java/pie/tomato/tomatomarket/application/MemberServiceTest.java
+++ b/src/test/java/pie/tomato/tomatomarket/application/MemberServiceTest.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import pie.tomato.tomatomarket.application.member.MemberService;
 import pie.tomato.tomatomarket.domain.Member;
 import pie.tomato.tomatomarket.support.SupportRepository;
 

--- a/src/test/java/pie/tomato/tomatomarket/application/unit/AuthServiceTest.java
+++ b/src/test/java/pie/tomato/tomatomarket/application/unit/AuthServiceTest.java
@@ -12,7 +12,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.transaction.annotation.Transactional;
 
-import pie.tomato.tomatomarket.application.AuthService;
+import pie.tomato.tomatomarket.application.oauth.AuthService;
 import pie.tomato.tomatomarket.application.oauth.KakaoClient;
 import pie.tomato.tomatomarket.domain.OAuthUser;
 import pie.tomato.tomatomarket.exception.BadRequestException;

--- a/src/test/java/pie/tomato/tomatomarket/application/unit/ImageServiceTest.java
+++ b/src/test/java/pie/tomato/tomatomarket/application/unit/ImageServiceTest.java
@@ -15,8 +15,8 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.transaction.annotation.Transactional;
 
-import pie.tomato.tomatomarket.application.ImageService;
-import pie.tomato.tomatomarket.application.ImageUploader;
+import pie.tomato.tomatomarket.application.image.ImageService;
+import pie.tomato.tomatomarket.application.image.ImageUploader;
 import pie.tomato.tomatomarket.domain.ImageFile;
 
 @Transactional


### PR DESCRIPTION
## Issues
- #18 

## What is this PR? 👓
- 상품 상태 변경에 대한 PR 입니다. 
  - ex. `"판매중"` -> `"예약중"`
- 코드 리팩토링을 했습니다.

## Key changes 🔑 & 📖 공부하면서 배웠던 것
- 상품의 여러개의 이미지를 저장할 때 insert 쿼리가 여러번 날라가는 `saveAll()` 메서드가 아닌 jdbcTemplate을 사용한 `bulk insert` 기능으로 변경했습니다.
- memberId 하나만 받는 생성자 대신 `memberRepository.getReferenceId()`로 변경했습니다.
  - `memberRepository.getReferenceId()` 메서드를 이용하면 멤버 엔티티의 프록시를 가져오게 되는데, 프록시여도 식별자(PK)값은 존재하게 되는 걸 알았습니다. 하여 member의 Id만 필요로 하는 Item 클래스에 프록시 객체인 member를 저장하도록 변경하였습니다.
### `getReferenceId()` 메서드가 데이터를 가져오는  방식
  - 지연로딩(Lazy Loading) :  엔티티를 실제로 사용할 때까지 데이터베이스 조회를 지연합니다
  - 실제 엔티티 객체가 필요한 시점에서는 프록시 객체가 아닌 실제 엔티티를 반환합니다. 처음에는 Proxy객체로 가지고 있습니다.