### PR TITLE
[feat] 상품 목록 조회 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,15 @@
+buildscript {
+    ext {
+        queryDslVersion = "5.0.0"
+    }
+}
+
 plugins {
     id 'java'
     id 'org.springframework.boot' version '2.7.16'
     id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+    // QueryDSL
+    id 'com.ewerk.gradle.plugins.querydsl' version '1.0.10'
 }
 
 group = 'pie'
@@ -39,8 +47,30 @@ dependencies {
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.518'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.518'
 
+    // QueryDSL
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+    annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}"
+
 }
 
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+/** QueryDSL start **/
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+sourceSets {
+    main.java.srcDir querydslDir
+}
+configurations {
+    querydsl.extendsFrom compileClasspath
+}
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
+}
+/** QueryDSL end **/

--- a/src/main/java/pie/tomato/tomatomarket/domain/Region.java
+++ b/src/main/java/pie/tomato/tomatomarket/domain/Region.java
@@ -16,5 +16,6 @@ public class Region {
 	@Id
 	@GeneratedValue(strategy = IDENTITY)
 	private Long id;
-	private String name;
+	private String fullAddressName;
+	private String addressName;
 }

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/config/QueryDslConfig.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/config/QueryDslConfig.java
@@ -1,0 +1,17 @@
+package pie.tomato.tomatomarket.infrastructure.config;
+
+import javax.persistence.EntityManager;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+@Configuration
+public class QueryDslConfig {
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory(EntityManager em) {
+		return new JPAQueryFactory(em);
+	}
+}

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/ItemRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/ItemRepository.java
@@ -1,8 +1,0 @@
-package pie.tomato.tomatomarket.infrastructure.persistence;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import pie.tomato.tomatomarket.domain.Item;
-
-public interface ItemRepository extends JpaRepository<Item, Long> {
-}

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/PaginationRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/PaginationRepository.java
@@ -1,0 +1,23 @@
+package pie.tomato.tomatomarket.infrastructure.persistence;
+
+import java.util.List;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.SliceImpl;
+
+import pie.tomato.tomatomarket.presentation.request.item.ItemResponse;
+
+public interface PaginationRepository {
+
+	default SliceImpl<ItemResponse> checkLastPage(int size, List<ItemResponse> results) {
+
+		boolean hasNext = false;
+
+		if (results.size() > size) {
+			hasNext = true;
+			results.remove(size);
+		}
+
+		return new SliceImpl<>(results, PageRequest.ofSize(size), hasNext);
+	}
+}

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/item/ItemPaginationRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/item/ItemPaginationRepository.java
@@ -1,0 +1,45 @@
+package pie.tomato.tomatomarket.infrastructure.persistence.item;
+
+import static pie.tomato.tomatomarket.domain.QItem.*;
+
+import java.util.List;
+
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+import pie.tomato.tomatomarket.presentation.request.item.ItemResponse;
+
+@RequiredArgsConstructor
+@Repository
+public class ItemPaginationRepository {
+
+	private final JPAQueryFactory queryFactory;
+	private final ItemRepository itemRepository;
+
+	public Slice<ItemResponse> findByIdAndRegion(Long itemId, String region, int size, Long categoryId) {
+		List<ItemResponse> itemResponses = queryFactory.select(Projections.fields(ItemResponse.class,
+				item.id.as("itemId"),
+				item.thumbnail.as("thumbnailUrl"),
+				item.title,
+				item.region.as("tradingRegion"),
+				item.createdAt,
+				item.price,
+				item.status,
+				item.wishCount,
+				item.chatCount,
+				item.member.nickname.as("sellerId")))
+			.from(item)
+			.where(itemRepository.lessThanItemId(itemId),
+				itemRepository.equalCategoryId(categoryId),
+				itemRepository.equalTradingRegion(region)
+			)
+			.orderBy(item.createdAt.desc())
+			.limit(size + 1)
+			.fetch();
+		return itemRepository.checkLastPage(size, itemResponses);
+	}
+}

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/item/ItemPaginationRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/item/ItemPaginationRepository.java
@@ -31,7 +31,7 @@ public class ItemPaginationRepository {
 				item.status,
 				item.wishCount,
 				item.chatCount,
-				item.member.nickname.as("sellerId")))
+				item.member.nickname.as("isSeller")))
 			.from(item)
 			.where(itemRepository.lessThanItemId(itemId),
 				itemRepository.equalCategoryId(categoryId),

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/item/ItemRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/item/ItemRepository.java
@@ -2,18 +2,14 @@ package pie.tomato.tomatomarket.infrastructure.persistence.item;
 
 import static pie.tomato.tomatomarket.domain.QItem.*;
 
-import java.util.List;
-
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 
 import pie.tomato.tomatomarket.domain.Item;
-import pie.tomato.tomatomarket.presentation.request.item.ItemResponse;
+import pie.tomato.tomatomarket.infrastructure.persistence.PaginationRepository;
 
-public interface ItemRepository extends JpaRepository<Item, Long> {
+public interface ItemRepository extends JpaRepository<Item, Long>, PaginationRepository {
 
 	default BooleanExpression lessThanItemId(Long itemId) {
 		if (itemId == null) {
@@ -36,17 +32,5 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
 		}
 
 		return item.region.like(region + "%");
-	}
-
-	default SliceImpl<ItemResponse> checkLastPage(int size, List<ItemResponse> results) {
-
-		boolean hasNext = false;
-
-		if (results.size() > size) {
-			hasNext = true;
-			results.remove(size);
-		}
-
-		return new SliceImpl<>(results, PageRequest.ofSize(size), hasNext);
 	}
 }

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/item/ItemRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/item/ItemRepository.java
@@ -1,0 +1,52 @@
+package pie.tomato.tomatomarket.infrastructure.persistence.item;
+
+import static pie.tomato.tomatomarket.domain.QItem.*;
+
+import java.util.List;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+
+import pie.tomato.tomatomarket.domain.Item;
+import pie.tomato.tomatomarket.presentation.request.item.ItemResponse;
+
+public interface ItemRepository extends JpaRepository<Item, Long> {
+
+	default BooleanExpression lessThanItemId(Long itemId) {
+		if (itemId == null) {
+			return null;
+		}
+
+		return item.id.lt(itemId);
+	}
+
+	default BooleanExpression equalCategoryId(Long categoryId) {
+		if (categoryId == null) {
+			return null;
+		}
+		return item.category.id.eq(categoryId);
+	}
+
+	default BooleanExpression equalTradingRegion(String region) {
+		if (region == null) {
+			return null;
+		}
+
+		return item.region.like(region + "%");
+	}
+
+	default SliceImpl<ItemResponse> checkLastPage(int size, List<ItemResponse> results) {
+
+		boolean hasNext = false;
+
+		if (results.size() > size) {
+			hasNext = true;
+			results.remove(size);
+		}
+
+		return new SliceImpl<>(results, PageRequest.ofSize(size), hasNext);
+	}
+}

--- a/src/main/java/pie/tomato/tomatomarket/presentation/ItemController.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/ItemController.java
@@ -5,18 +5,22 @@ import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import lombok.RequiredArgsConstructor;
 import pie.tomato.tomatomarket.application.item.ItemService;
+import pie.tomato.tomatomarket.presentation.dto.CustomSlice;
 import pie.tomato.tomatomarket.presentation.request.item.ItemRegisterRequest;
+import pie.tomato.tomatomarket.presentation.request.item.ItemResponse;
 import pie.tomato.tomatomarket.presentation.request.item.ItemStatusModifyRequest;
 import pie.tomato.tomatomarket.presentation.support.AuthPrincipal;
 import pie.tomato.tomatomarket.presentation.support.Principal;
@@ -43,5 +47,13 @@ public class ItemController {
 		@RequestBody ItemStatusModifyRequest request) {
 		itemService.modifyStatus(itemId, principal, request);
 		return ResponseEntity.ok().build();
+	}
+
+	@GetMapping
+	public ResponseEntity<CustomSlice<ItemResponse>> findAll(@RequestParam String region,
+		@RequestParam(required = false, defaultValue = "10") int size,
+		@RequestParam(required = false) Long cursor,
+		@RequestParam(required = false) Long categoryId) {
+		return ResponseEntity.ok().body(itemService.findAll(region, size, cursor, categoryId));
 	}
 }

--- a/src/main/java/pie/tomato/tomatomarket/presentation/dto/CustomSlice.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/dto/CustomSlice.java
@@ -1,0 +1,26 @@
+package pie.tomato.tomatomarket.presentation.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+public class CustomSlice<T> {
+
+	private final List<T> contents;
+	private final Paging paging;
+
+	public CustomSlice(List<T> contents, Long nextCursor, boolean hasNext) {
+		this.contents = contents;
+		this.paging = new Paging(nextCursor, hasNext);
+	}
+
+	@AllArgsConstructor
+	@Getter
+	public static class Paging {
+
+		private final Long nextCursor;
+		private final boolean hasNext;
+	}
+}

--- a/src/main/java/pie/tomato/tomatomarket/presentation/request/item/ItemResponse.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/request/item/ItemResponse.java
@@ -1,0 +1,21 @@
+package pie.tomato.tomatomarket.presentation.request.item;
+
+import java.time.LocalDateTime;
+
+import lombok.Getter;
+import pie.tomato.tomatomarket.domain.ItemStatus;
+
+@Getter
+public class ItemResponse {
+
+	private Long itemId;
+	private String thumbnailUrl;
+	private String title;
+	private String tradingRegion;
+	private LocalDateTime createdAt;
+	private Long price;
+	private ItemStatus status;
+	private Long chatCount;
+	private Long wishCount;
+	private String isSeller;
+}

--- a/src/test/java/pie/tomato/tomatomarket/application/ItemServiceTest.java
+++ b/src/test/java/pie/tomato/tomatomarket/application/ItemServiceTest.java
@@ -1,6 +1,7 @@
 package pie.tomato.tomatomarket.application;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import java.nio.charset.StandardCharsets;
@@ -127,7 +128,23 @@ class ItemServiceTest {
 		CustomSlice<ItemResponse> findItems = itemService.findAll(null, 10, null, null);
 
 		// then
-		assertThat(findItems.getContents().size()).isEqualTo(10);
+		assertAll(
+			() -> assertThat(findItems.getContents().size()).isEqualTo(10),
+			// 0번째로 나온 객체의 생성시간이 가장 마지막에 나온 객체의 생성시간보다 이후인지 확인하는 메서드
+			() -> assertThat(findItems.getContents().get(0).getCreatedAt())
+				.isAfter(findItems.getContents().get(findItems.getContents().size() - 1).getCreatedAt()),
+			() -> assertThat(findItems.getContents().get(0)).hasFieldOrProperty("itemId"),
+			() -> assertThat(findItems.getContents().get(0)).hasFieldOrProperty("thumbnailUrl"),
+			() -> assertThat(findItems.getContents().get(0)).hasFieldOrProperty("title"),
+			() -> assertThat(findItems.getContents().get(0)).hasFieldOrProperty("tradingRegion"),
+			() -> assertThat(findItems.getContents().get(0)).hasFieldOrProperty("createdAt"),
+			() -> assertThat(findItems.getContents().get(0)).hasFieldOrProperty("price"),
+			() -> assertThat(findItems.getContents().get(0)).hasFieldOrProperty("status"),
+			() -> assertThat(findItems.getContents().get(0)).hasFieldOrProperty("chatCount"),
+			() -> assertThat(findItems.getContents().get(0)).hasFieldOrProperty("wishCount"),
+			() -> assertThat(findItems.getContents().get(0)).hasFieldOrProperty("isSeller")
+		);
+
 	}
 
 	@DisplayName("카테고리별 상품 목록 조회에 성공한다.")


### PR DESCRIPTION
## Issues
- #20 

## What is this PR? 👓
- 상품 목록 조회에 대한 PR입니다.

## Key changes 🔑
- QueryDsl에 대한 의존성 추가
- 페이징을 사용한 상품 목록 조회 / 카테고리별 상품 목록 조회
## 📖 공부하면서 배웠던 것
### 📌 Pagination을 사용하는 이유
사용자가 애플리케이션을 사용 중 게시판, 상품 목록 등을 요청할 때 결과 값이 총 100만개일 경우 매번 전체를 전부 가져오게되면 매우 느려지며 사용자는 불편을 느끼게된다. 하지만 데이터를 조금씩 (20~100개) 나눠서 가져오고 사용자가 원하는 경우 다음 데이터를 가져오게 되면 훨씬 빠르고 사용자도 애플리케이션에 대해 만족할 것이다. 이러한 이유로 Pagination을 사용한다.
### Pagination 종류
- offset 방식 : offset과 limit 예약어를 통하여 select의 전체 결과 중 일부만 가져오는 방법이다.
- no-offset(=cursor) 방식 : cursor는 어떠한 row를 가르키는 포인터이고, 이 cursor가 가르키는 row로부터 일정 개수만큼 가져오는 방식이다.
### 📌 offset
**offset**이란 sql에서 조회를 시작할 **기준점을 의미**하고 **limit**는 **조회할 결과의 개수를 의미**한다. 예를 들어 아래와 같은 쿼리는
~~~sql
SELECT * FROM {테이블 이름} LIMIT 20 OFFSET 60;
~~~
60번째 행부터 20개의 행을 읽겠다는 의미이다. (이때 행은 0부터 시작.)
 offset은 조회를 한 결과에서 limit으로 지정한 개수만큼만 반환하고 나머지는 버리는 식으로 동작한다. 
위 쿼리로 예를 들자면 60번째 데이터 부터 20개를 조회하기 위해서 80개의 데이터를 모두 읽은 뒤, 앞의 필요없는 60개의 데이터는 버려야 한다. 
예시처럼 적은양의 데이터를 조회할 때는 성능적인 문제가 발생하지 않지만, 전체 데이터의 개수가 많아질수록 버려지는 데이터의 양이 많아져 문제가 된다. 
### offset 방식의 단점
- 뒷부분 쿼리 시 속도 저하
    
    위에서 말했듯이 offset방식은 여러개의 데이터를 한번에 가져와 필요한 만큼만 출력하고 나머지는 버리게 된다. 예를 들어 1,000,000개의 데이터를 가지고 있고, 100,000번째의 데이터에서 20개만 필요하다고 가정해보자. 내가 필요한 만큼은 20개인데 데이터는 100,020개를 가져오고 100,000개의 데이터는 버려지게 된다. 그 숫자는 커지면 커질수록 속도는 저하된다.
    
- 데이터 누락
    offset 방식은 데이터의 잦은 추가와 삭제가 있을 경우 데이터의 중복과 누락이 발생할 수 있다. offset 방식은 전체 데이터 중 offset만큼 건너 뛰며 이때 이전에 받은 데이터를 고려하지 않고 매번 새로 계산한다.
    - 예를 들어, 사용자가 1페이지의 1번부터 5번까지의 상품을 보고있는데 관리자가 4,5번 상품을 삭제했다고 가정시 사용자의 2페이지 요청시 데이터베이스는
    `나는 1번부터 5개를 줬는.. 어? 4번 5번이 없네? 그럼 7번까지 줬구나 !`
     라고 생각하고 2페이지는 8번 상품부터 5개의 데이터를 보내줄것이다. 그러면 6번상품과 7번상품의 데이터가 누락이 된다.

   이는 해당 서비스를 재접속하거나 다시 1페이지를 요청하지 않는 이상(새로고침) 다시는 볼 수 없게 된다.
- 데이터 중복
<img src="https://github.com/pie2457/Tomato-market/assets/104147789/b66bdd60-241f-4fba-8037-e7159cc44fac" width="700" height="140">

페이지를 이동하는 중간에 데이터가 삽입, 혹은 삭제 등의 작업이 발생한다면 다른 페이지에 영향을 주게 된다. 예를 들어, 1페이지에서 3개의 데이터를 조회한 후 2페이지로 넘어가는 과정에서 새로운 데이터가 추가된다면? 

<img src="https://github.com/pie2457/Tomato-market/assets/104147789/7beb34ea-ea67-4151-ad2c-496eaf0a0404" width="730" height="140">

이전 페이지에서 읽었던 데이터가 밀려와 이미 조회한 데이터를 중복 조회하게 된다.
### 📌 no-offset(=cursor)
**no-offset(=cursor)** 방식은 이전 페이지의 마지막 데이터의 id 값을 기억하고, 다음 페이지를 요청할 때 이 id 값 이후의 데이터를 가져오는 방식이다. 이를 통해 매번 offset 값을 계산하지 않아도 되기 때문에 데이터베이스에서 더욱 효율적으로 데이터를 가져올 수 있다. 이 방식을 사용할 경우 기준점 이전의 데이터도 모두 조회하던 offset과 달리 기준점(=cursor)부터 limit의 개수만 조회하기 때문에 데이터의 개수가 많아져도 성능 문제가 발생하지 않는다. 보통 무한스크롤이라 칭하기도 하고, sns에서 많이 사용되고 있다.
~~~sql
SELECT * FROM {테이블} 
WHERE {조건문}
AND id < lastId
ORDER BY id DESC 
LIMIT {컨텐츠개수}
~~~
예를 들어, 유저가 N번째 데이터부터 5개의 데이터를 조회하고 싶다고 요청한다면 직전에 조회한 데이터들 중 마지막 데이터의 id를 조건문으로 사용하여 이전에 조회했던 데이터들을 읽을 필요 없이 원하는 데이터로 건너 뛸 수 있게 된다. 때문에 페이지가 뒤로 가더라도 처음 페이지를 읽은 것과 동일한 성능을 가지게 된다. 
<img src="https://github.com/pie2457/Tomato-market/assets/104147789/20e68d79-76e5-4b33-a029-175be51235b2" width="600" height="300">
또한 페이지를 순차적으로 가져오기 때문에 중간에 삽입, 삭제, 업데이트 등의 작업이 발생해도 다른 페이지에 영향을 미치지 않는다. 이를 통해 데이터베이스의 부하를 줄일 수 있다.
아까와 동일한 예시로 첫 번째 페이지에서 3개의 데이터를 조회한 후 다음 페이지로 넘어가는 사이에 새로운 데이터가 추가되더라도 다음 페이지에 영향을 주지 않는다. (동일한 데이터를 중복 조회할 일이 없어진다.)
<img src="https://github.com/pie2457/Tomato-market/assets/104147789/6ae45077-3aba-4e73-9615-376b7f65ee9c" width="700" height="150">
<img src="https://github.com/pie2457/Tomato-market/assets/104147789/bfd935db-8f4d-41d5-94f6-d5fd25d87520" width="700" height="120">