### PR TITLE
[feat] 상품 삭제 기능 구현

### DIFF
--- a/src/main/java/pie/tomato/tomatomarket/application/item/ItemService.java
+++ b/src/main/java/pie/tomato/tomatomarket/application/item/ItemService.java
@@ -153,14 +153,13 @@ public class ItemService {
 
 		imageService.deleteImageFromS3(findItem.getThumbnail());
 		deleteAllRelatedItem(itemId, principal.getMemberId());
-
 	}
 
 	private void deleteAllRelatedItem(Long itemId, Long memberId) {
 		imageRepository.deleteByItemId(itemId);
 		wishRepository.deleteByItemIdAndMemberId(itemId, memberId);
-		chatroomRepository.deleteByItemId(itemId);
-		itemRepository.deleteItemByIdAndMemberId(itemId, memberId);
+		chatroomRepository.deleteAllByItemId(itemId);
+		itemRepository.deleteById(itemId);
 	}
 
 	private void verifyExistsMember(Long memberId) {

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/ChatroomRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/ChatroomRepository.java
@@ -1,0 +1,10 @@
+package pie.tomato.tomatomarket.infrastructure.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import pie.tomato.tomatomarket.domain.Chatroom;
+
+public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
+
+	void deleteByItemId(Long itemId);
+}

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/ChatroomRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/ChatroomRepository.java
@@ -1,10 +1,15 @@
 package pie.tomato.tomatomarket.infrastructure.persistence;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import pie.tomato.tomatomarket.domain.Chatroom;
 
 public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
 
-	void deleteByItemId(Long itemId);
+	@Modifying(clearAutomatically = true, flushAutomatically = true)
+	@Query("delete from Chatroom chatroom where chatroom.item.id = :itemId")
+	void deleteAllByItemId(@Param("itemId") Long itemId);
 }

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/WishRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/WishRepository.java
@@ -1,0 +1,10 @@
+package pie.tomato.tomatomarket.infrastructure.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import pie.tomato.tomatomarket.domain.Wish;
+
+public interface WishRepository extends JpaRepository<Wish, Long> {
+
+	void deleteByItemIdAndMemberId(Long itemId, Long memberId);
+}

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/image/ImageRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/image/ImageRepository.java
@@ -11,12 +11,12 @@ import pie.tomato.tomatomarket.domain.Image;
 
 public interface ImageRepository extends JpaRepository<Image, Long>, ImageRepositoryCustom {
 
-	@Modifying
+	@Modifying(clearAutomatically = true, flushAutomatically = true)
 	@Query("delete from Image image where image.item.id = :itemId and image.imageUrl in :imageUrls")
 	void deleteImageByItemIdAndImageUrls(@Param("itemId") Long itemId,
 		@Param("imageUrls") List<String> imageUrls);
 
-	@Modifying
+	@Modifying(clearAutomatically = true, flushAutomatically = true)
 	@Query("delete from Image image where image.item.id = :itemId and image.imageUrl = :imageUrl")
 	void deleteImageByItemIdAndImageUrl(@Param("itemId") Long itemId,
 		@Param("imageUrl") String imageUrl);

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/image/ImageRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/image/ImageRepository.java
@@ -20,4 +20,6 @@ public interface ImageRepository extends JpaRepository<Image, Long>, ImageReposi
 	@Query("delete from Image image where image.item.id = :itemId and image.imageUrl = :imageUrl")
 	void deleteImageByItemIdAndImageUrl(@Param("itemId") Long itemId,
 		@Param("imageUrl") String imageUrl);
+
+	void deleteByItemId(Long itemId);
 }

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/item/ItemRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/item/ItemRepository.java
@@ -16,6 +16,8 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
 
 	boolean existsItemById(Long itemId);
 
+	void deleteItemByIdAndMemberId(Long itemId, Long memberId);
+
 	default BooleanExpression lessThanItemId(Long itemId) {
 		if (itemId == null) {
 			return null;

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/item/ItemRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/item/ItemRepository.java
@@ -16,8 +16,6 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
 
 	boolean existsItemById(Long itemId);
 
-	void deleteItemByIdAndMemberId(Long itemId, Long memberId);
-
 	default BooleanExpression lessThanItemId(Long itemId) {
 		if (itemId == null) {
 			return null;

--- a/src/main/java/pie/tomato/tomatomarket/presentation/ItemController.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/ItemController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -66,6 +67,13 @@ public class ItemController {
 		@RequestPart(value = "images", required = false) List<MultipartFile> itemImages,
 		@RequestPart(value = "thumbnailImage", required = false) MultipartFile thumbnail) {
 		itemService.modifyItem(itemId, principal, modifyRequest, itemImages, thumbnail);
+		return ResponseEntity.ok().build();
+	}
+
+	@DeleteMapping("/{itemId}")
+	public ResponseEntity<Void> deleteItem(@PathVariable Long itemId,
+		@AuthPrincipal Principal principal) {
+		itemService.deleteItem(itemId, principal);
 		return ResponseEntity.ok().build();
 	}
 }

--- a/src/test/java/pie/tomato/tomatomarket/application/ItemServiceTest.java
+++ b/src/test/java/pie/tomato/tomatomarket/application/ItemServiceTest.java
@@ -247,6 +247,32 @@ class ItemServiceTest {
 		);
 	}
 
+	@DisplayName("상품 삭제에 성공한다.")
+	@Test
+	void deleteItem() {
+		// given
+		Member member = setupMember();
+		Category category = setupCategory();
+		Principal principal = Principal.builder()
+			.nickname(member.getNickname())
+			.email(member.getEmail())
+			.memberId(member.getId())
+			.build();
+
+		Item item = supportRepository.save(new Item("머리끈", "머리끈 100개 팝니다.", 3000L, "thumbnail", ItemStatus.ON_SALE,
+			"역삼1동", 0L, 0L, 0L, LocalDateTime.now(), member, category));
+
+		// when
+		itemService.deleteItem(item.getId(), principal);
+
+		// then
+		assertAll(
+			() -> assertThat(supportRepository.findById(item.getId(), Item.class)).isNull(),
+			() -> assertThat(imageRepository.findById(item.getId())).isEmpty()
+		);
+
+	}
+
 	private ItemRegisterRequest createItemRegisterRequest(Category category) {
 		return new ItemRegisterRequest("수박",
 			5000L,

--- a/src/test/java/pie/tomato/tomatomarket/application/ItemServiceTest.java
+++ b/src/test/java/pie/tomato/tomatomarket/application/ItemServiceTest.java
@@ -41,7 +41,6 @@ class ItemServiceTest {
 	private ItemService itemService;
 	@Autowired
 	private ImageRepository imageRepository;
-
 	@Autowired
 	private FakeImageUploader imageUploader;
 	@Autowired
@@ -270,7 +269,6 @@ class ItemServiceTest {
 			() -> assertThat(supportRepository.findById(item.getId(), Item.class)).isNull(),
 			() -> assertThat(imageRepository.findById(item.getId())).isEmpty()
 		);
-
 	}
 
 	private ItemRegisterRequest createItemRegisterRequest(Category category) {

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -4,3 +4,7 @@ spring:
       test
     include:
       secret
+
+logging.level:
+  org.hibernate.SQL: debug
+#  org.hibernate.type: trace


### PR DESCRIPTION
## Issues
- #24 

## What is this PR? 👓
- 상품 삭제 기능에 대한 PR입니다.

## Key changes 🔑 
- 상품 삭제 기능
- 상품 삭제 테스트 작성

##  📖 공부하면서 배웠던 것
### `@Modifying` 이란 ?
- `@Query` 어노테이션(JPQL Query, Native Query)을 통해 작성된 INSERT, UPDATE, DELETE(SELECT 제외) 쿼리에서 사용되는 어노테이션입니다.
  - `@Query`를 사용시 `@Modifying` 애노테이션을 붙여주지 않으면 `QueryExecutionRequestException`이 발생한다.
- __기본적으로 JpaRepository에서 제공하는 메서드 혹은 메서드 네이밍으로 만들어진 쿼리에는 적용되지 않습니다__.
- clearAutomatically, flushAutomatically 속성을 변경 할 수 있으며 **주로 벌크 연산과 같이 이용**됩니다.
  - clearAutomatically ( default: false )
  - flushAutomatically ( default: false )
### 📌 clearAutomatically ?
JPA에서 1차 캐시는 DB의 접근 횟수를 줄여주고 다양한 성능 개선의 효과를 가져다주지만 `@Modifying`과 `@Query`를 이용한 벌크 연산에서는 이 기능때문에 예측 불가능한 결과가 나올 수 있다.
JPA에서 조회를 실행할 때 1차 캐시를 확인해서 해당 엔티티가 1차 캐시에 존재한다면 DB에 접근하지 않고, 1차캐시의 엔티티를 반환한다. 하지만 **벌크연산은 1차 캐시를 포함한 영속성 컨텍스트를 무시하고 바로 QUERY를 실행하기 때문에 영속성 컨텍스트는 데이터 변경을 알 수 없다. 즉, 벌크연산을 실행할 때 싱크가 맞지 않게된다**.
이 문제를 해결하기위해 `@Modifying`어노테이션은 **ClearAutomatically**라는 속성이 존재하는 것이다. defalt가 False인 이 속성을 true로 변경해준다면 **벌크연산 직후 자동으로 영속성 컨텍스트를 clear해준다**. 영속성 컨텍스트를 clear해준다면 조회를 실행할 때 이미 update결과가 진행되어진 DB를 조회하기 때문에 데이터의 동기화문제를 해결할 수 있다.
> 한줄 요약
`@Query` 쿼리 실행 후에 영속성 컨텍스트를 비워서 DB에서 수정된 값을 정상적으로 조회할 수 있게 하기 위해 사용한다.
### 📌 flushAutomatically ?
`clearAutomatically`는 JPQL을 실행한 후 동작하지만 `flushAutomatically` JPQL을 DB에 날리기 전 영속성 컨텍스트를 flush해준다.
여기서 한가지 의문이 생겼다. 트랜잭션 내에서 JPQL를 실행하면, 영속성 컨텍스트가 flush 된다고 알고 있는데, `flushAutomatically` 옵션은 왜 생긴것인지 궁금해 찾아보았다.

> AUTO flush
By default, Hibernate uses the AUTO flush mode which triggers a flush in the following circumstances:
prior to committing a Transaction
prior to executing a JPQL/HQL query that overlaps with the queued entity actions
before executing any native SQL query that has no registered synchronization

내가 이해하기로는 실행될 JPQL에 의해서 영향을 받는 Entity들에 대해서만 flush가 된다는 것이었다.
(물론 이건 FlushMode 옵션이 기본값인 FlushModeType.AUTO 일 때)

간단한 로직을 통해 더 쉽게 이해해보자.
~~~java
@Transactional
	public void update(Long productId) {
		Product product = productRepository.findProductById(productId);
		
		product.changePrice("10000");  // 1번
		bookmarkRepository.deleteByProductId(product.getId());  // 2번
                // deleteByProductId()는 clearAutomatically=true 옵션을 설정해놨다.
	}
~~~~
1. 상품의 가격을 변경 시킨다.
2. 북마크로 설정해놓은 아이템을 해지 시킨다.

위의 경우 product 가격을 10000원으로 변경하는 쿼리는 메서드가 끝날 때, Dirty Checking(변경 감지)에 의해서 Transaction이 커밋되면서 flush 돼야한다. 하지만 해당 쿼리는 어디서도 발생하지 않는다. 왜냐하면  Hibernate가 deleteByProductId()의 쿼리가 product에는 영향을 미치지 않는다고 판단하여 product.changePrice() 쿼리를 flush를 시키지 않고, deleteByProductId() 호출하며`clearAutomatically=true` 옵션에 의해서 영속성 컨텍스트가 싹 비워지기 때문이다.
즉, 쓰기 지연 저장소에 저장되어 있던 product.changePrice() 쿼리도 삭제되어 버렸다. 이러한 문제점들로 인해 `flushAutomatically` 옵션을 사용한다.

> 한줄 요약
@Query 쿼리 실행 전에 쓰기 지연 저장소에 남아있는 쿼리를 미리 flush 하고자 할 때 사용한다

[reference] 
- https://docs.jboss.org/hibernate/orm/5.4/userguide/html_single/Hibernate_User_Guide.html#flushing-auto
- https://velog.io/@gruzzimo/JPA-Modifying%EC%9D%98-flushAutomatically-%EC%98%B5%EC%85%98%EC%9D%80-%EC%96%B8%EC%A0%9C-%EC%93%B0%EC%A7%80