### PR TITLE
[feat] 상품 상세페이지 조회

### DIFF
--- a/src/main/java/pie/tomato/tomatomarket/application/item/ItemService.java
+++ b/src/main/java/pie/tomato/tomatomarket/application/item/ItemService.java
@@ -29,8 +29,8 @@ import pie.tomato.tomatomarket.infrastructure.persistence.item.ItemRepository;
 import pie.tomato.tomatomarket.presentation.dto.CustomSlice;
 import pie.tomato.tomatomarket.presentation.request.item.ItemModifyRequest;
 import pie.tomato.tomatomarket.presentation.request.item.ItemRegisterRequest;
-import pie.tomato.tomatomarket.presentation.request.item.ItemResponse;
 import pie.tomato.tomatomarket.presentation.request.item.ItemStatusModifyRequest;
+import pie.tomato.tomatomarket.presentation.response.item.ItemResponse;
 import pie.tomato.tomatomarket.presentation.support.Principal;
 
 @Service
@@ -97,7 +97,7 @@ public class ItemService {
 		verifyExistsMember(principal.getMemberId());
 		verifyExistsItem(itemId);
 
-		Item findItem = itemRepository.findItemByIdAndMemberId(itemId, principal.getMemberId())
+		Item findItem = itemRepository.findByIdAndMemberId(itemId, principal.getMemberId())
 			.orElseThrow(() -> new ForbiddenException(ErrorCode.ITEM_FORBIDDEN));
 
 		deleteImages(modifyRequest, findItem);
@@ -120,7 +120,7 @@ public class ItemService {
 	}
 
 	private String updateThumbnail(Item item, String thumbnailUrl, MultipartFile thumbnail) {
-		if (thumbnailUrl == null || thumbnailUrl.isEmpty()) {
+		if (thumbnailUrl == null || !thumbnailUrl.equals(item.getThumbnail())) {
 			return item.getThumbnail();
 		}
 		imageService.deleteImageFromS3(thumbnailUrl);
@@ -148,7 +148,7 @@ public class ItemService {
 		verifyExistsMember(principal.getMemberId());
 		verifyExistsItem(itemId);
 
-		Item findItem = itemRepository.findItemByIdAndMemberId(itemId, principal.getMemberId())
+		Item findItem = itemRepository.findByIdAndMemberId(itemId, principal.getMemberId())
 			.orElseThrow(() -> new ForbiddenException(ErrorCode.ITEM_FORBIDDEN));
 
 		imageService.deleteImageFromS3(findItem.getThumbnail());

--- a/src/main/java/pie/tomato/tomatomarket/application/item/ItemService.java
+++ b/src/main/java/pie/tomato/tomatomarket/application/item/ItemService.java
@@ -30,6 +30,7 @@ import pie.tomato.tomatomarket.presentation.dto.CustomSlice;
 import pie.tomato.tomatomarket.presentation.request.item.ItemModifyRequest;
 import pie.tomato.tomatomarket.presentation.request.item.ItemRegisterRequest;
 import pie.tomato.tomatomarket.presentation.request.item.ItemStatusModifyRequest;
+import pie.tomato.tomatomarket.presentation.response.item.ItemDetailResponse;
 import pie.tomato.tomatomarket.presentation.response.item.ItemResponse;
 import pie.tomato.tomatomarket.presentation.support.Principal;
 
@@ -153,6 +154,17 @@ public class ItemService {
 
 		imageService.deleteImageFromS3(findItem.getThumbnail());
 		deleteAllRelatedItem(itemId, principal.getMemberId());
+	}
+
+	public ItemDetailResponse itemDetails(Long itemId) {
+		Item findItem = itemRepository.findById(itemId)
+			.orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_ITEM));
+		boolean isInWishList = wishRepository.existsByItemIdAndMemberId(itemId, findItem.getMember().getId());
+		List<Image> images = imageRepository.findByItemId(itemId);
+		List<String> imageUrls = images.stream()
+			.map(Image::getImageUrl)
+			.collect(Collectors.toList());
+		return ItemDetailResponse.toEntity(findItem, isInWishList, imageUrls);
 	}
 
 	private void deleteAllRelatedItem(Long itemId, Long memberId) {

--- a/src/main/java/pie/tomato/tomatomarket/domain/Image.java
+++ b/src/main/java/pie/tomato/tomatomarket/domain/Image.java
@@ -4,7 +4,6 @@ import static javax.persistence.FetchType.*;
 import static javax.persistence.GenerationType.*;
 import static lombok.AccessLevel.*;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -41,10 +40,8 @@ public class Image {
 	}
 
 	public static List<Image> createImage(List<String> imageUrls, Item item) {
-		List<Image> images = new ArrayList<>();
-		imageUrls.stream()
+		return imageUrls.stream()
 			.map(url -> new Image(url, item))
 			.collect(Collectors.toList());
-		return images;
 	}
 }

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/WishRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/WishRepository.java
@@ -7,4 +7,6 @@ import pie.tomato.tomatomarket.domain.Wish;
 public interface WishRepository extends JpaRepository<Wish, Long> {
 
 	void deleteByItemIdAndMemberId(Long itemId, Long memberId);
+
+	boolean existsByItemIdAndMemberId(Long itemId, Long memberId);
 }

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/image/ImageRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/image/ImageRepository.java
@@ -11,15 +11,17 @@ import pie.tomato.tomatomarket.domain.Image;
 
 public interface ImageRepository extends JpaRepository<Image, Long>, ImageRepositoryCustom {
 
-	@Modifying(clearAutomatically = true, flushAutomatically = true)
+	@Modifying
 	@Query("delete from Image image where image.item.id = :itemId and image.imageUrl in :imageUrls")
 	void deleteImageByItemIdAndImageUrls(@Param("itemId") Long itemId,
 		@Param("imageUrls") List<String> imageUrls);
 
-	@Modifying(clearAutomatically = true, flushAutomatically = true)
+	@Modifying
 	@Query("delete from Image image where image.item.id = :itemId and image.imageUrl = :imageUrl")
 	void deleteImageByItemIdAndImageUrl(@Param("itemId") Long itemId,
 		@Param("imageUrl") String imageUrl);
 
 	void deleteByItemId(Long itemId);
+
+	List<Image> findByItemId(Long itemId);
 }

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/item/ItemPaginationRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/item/ItemPaginationRepository.java
@@ -12,7 +12,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
 import pie.tomato.tomatomarket.infrastructure.persistence.util.PaginationUtil;
-import pie.tomato.tomatomarket.presentation.request.item.ItemResponse;
+import pie.tomato.tomatomarket.presentation.response.item.ItemResponse;
 
 @RequiredArgsConstructor
 @Repository

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/item/ItemRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/item/ItemRepository.java
@@ -12,7 +12,7 @@ import pie.tomato.tomatomarket.domain.Item;
 
 public interface ItemRepository extends JpaRepository<Item, Long> {
 
-	Optional<Item> findItemByIdAndMemberId(Long itemId, Long memberId);
+	Optional<Item> findByIdAndMemberId(Long itemId, Long memberId);
 
 	boolean existsItemById(Long itemId);
 

--- a/src/main/java/pie/tomato/tomatomarket/presentation/ItemController.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/ItemController.java
@@ -23,8 +23,9 @@ import pie.tomato.tomatomarket.application.item.ItemService;
 import pie.tomato.tomatomarket.presentation.dto.CustomSlice;
 import pie.tomato.tomatomarket.presentation.request.item.ItemModifyRequest;
 import pie.tomato.tomatomarket.presentation.request.item.ItemRegisterRequest;
-import pie.tomato.tomatomarket.presentation.request.item.ItemResponse;
 import pie.tomato.tomatomarket.presentation.request.item.ItemStatusModifyRequest;
+import pie.tomato.tomatomarket.presentation.response.item.ItemDetailResponse;
+import pie.tomato.tomatomarket.presentation.response.item.ItemResponse;
 import pie.tomato.tomatomarket.presentation.support.AuthPrincipal;
 import pie.tomato.tomatomarket.presentation.support.Principal;
 
@@ -71,9 +72,13 @@ public class ItemController {
 	}
 
 	@DeleteMapping("/{itemId}")
-	public ResponseEntity<Void> deleteItem(@PathVariable Long itemId,
-		@AuthPrincipal Principal principal) {
+	public ResponseEntity<Void> deleteItem(@PathVariable Long itemId, @AuthPrincipal Principal principal) {
 		itemService.deleteItem(itemId, principal);
 		return ResponseEntity.ok().build();
+	}
+
+	@GetMapping("/{itemId}")
+	public ResponseEntity<ItemDetailResponse> itemDetails(@PathVariable Long itemId) {
+		return ResponseEntity.ok().body(itemService.itemDetails(itemId));
 	}
 }

--- a/src/main/java/pie/tomato/tomatomarket/presentation/response/item/ItemDetailResponse.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/response/item/ItemDetailResponse.java
@@ -1,0 +1,42 @@
+package pie.tomato.tomatomarket.presentation.response.item;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import pie.tomato.tomatomarket.domain.Item;
+
+@Getter
+@AllArgsConstructor
+public class ItemDetailResponse {
+
+	private String nickname;
+	private String status;
+	private String title;
+	private String thumbnail;
+	private List<String> images;
+	private LocalDateTime createdAt;
+	private String content;
+	private Long price;
+	private Long chatCount;
+	private Long wishCount;
+	private Long viewCount;
+	private boolean isInWishList;
+
+	public static ItemDetailResponse toEntity(Item item, boolean isInWishList, List<String> images) {
+		return new ItemDetailResponse(
+			item.getMember().getNickname(),
+			item.getStatus().getName(),
+			item.getTitle(),
+			item.getThumbnail(),
+			images,
+			item.getCreatedAt(),
+			item.getContent(),
+			item.getPrice(),
+			item.getChatCount(),
+			item.getWishCount(),
+			item.getViewCount(),
+			isInWishList);
+	}
+}

--- a/src/main/java/pie/tomato/tomatomarket/presentation/response/item/ItemResponse.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/response/item/ItemResponse.java
@@ -1,4 +1,4 @@
-package pie.tomato.tomatomarket.presentation.request.item;
+package pie.tomato.tomatomarket.presentation.response.item;
 
 import java.time.LocalDateTime;
 

--- a/src/test/java/pie/tomato/tomatomarket/application/ItemServiceTest.java
+++ b/src/test/java/pie/tomato/tomatomarket/application/ItemServiceTest.java
@@ -296,9 +296,9 @@ class ItemServiceTest {
 			() -> assertThat(itemDetailResponse).hasFieldOrProperty("wishCount"),
 			() -> assertThat(itemDetailResponse).hasFieldOrProperty("viewCount"),
 			() -> assertThat(itemDetailResponse).hasFieldOrProperty("price"),
-			() -> assertThat(itemDetailResponse).hasFieldOrProperty("isInWishList"),
 			() -> assertThat(itemDetailResponse).hasFieldOrProperty("thumbnail"),
-			() -> assertThat(itemDetailResponse).hasFieldOrProperty("images")
+			() -> assertThat(itemDetailResponse).hasFieldOrProperty("images"),
+			() -> assertThat(itemDetailResponse.isInWishList()).isFalse()
 		);
 	}
 

--- a/src/test/java/pie/tomato/tomatomarket/application/ItemServiceTest.java
+++ b/src/test/java/pie/tomato/tomatomarket/application/ItemServiceTest.java
@@ -28,8 +28,9 @@ import pie.tomato.tomatomarket.infrastructure.persistence.image.ImageRepository;
 import pie.tomato.tomatomarket.presentation.dto.CustomSlice;
 import pie.tomato.tomatomarket.presentation.request.item.ItemModifyRequest;
 import pie.tomato.tomatomarket.presentation.request.item.ItemRegisterRequest;
-import pie.tomato.tomatomarket.presentation.request.item.ItemResponse;
 import pie.tomato.tomatomarket.presentation.request.item.ItemStatusModifyRequest;
+import pie.tomato.tomatomarket.presentation.response.item.ItemDetailResponse;
+import pie.tomato.tomatomarket.presentation.response.item.ItemResponse;
 import pie.tomato.tomatomarket.presentation.support.Principal;
 import pie.tomato.tomatomarket.support.SupportRepository;
 
@@ -268,6 +269,36 @@ class ItemServiceTest {
 		assertAll(
 			() -> assertThat(supportRepository.findById(item.getId(), Item.class)).isNull(),
 			() -> assertThat(imageRepository.findById(item.getId())).isEmpty()
+		);
+	}
+
+	@DisplayName("상품 상세 조회에 성공한다.")
+	@Test
+	void itemDetails() {
+		// given
+		Member member = setupMember();
+		Category category = setupCategory();
+
+		Item item = supportRepository.save(new Item("머리끈", "머리끈 100개 팝니다.", 3000L, "thumbnail", ItemStatus.ON_SALE,
+			"역삼1동", 0L, 0L, 0L, LocalDateTime.now(), member, category));
+
+		// when
+		ItemDetailResponse itemDetailResponse = itemService.itemDetails(item.getId());
+
+		// then
+		assertAll(
+			() -> assertThat(itemDetailResponse).hasFieldOrProperty("title"),
+			() -> assertThat(itemDetailResponse).hasFieldOrProperty("nickname"),
+			() -> assertThat(itemDetailResponse).hasFieldOrProperty("status"),
+			() -> assertThat(itemDetailResponse).hasFieldOrProperty("createdAt"),
+			() -> assertThat(itemDetailResponse).hasFieldOrProperty("content"),
+			() -> assertThat(itemDetailResponse).hasFieldOrProperty("chatCount"),
+			() -> assertThat(itemDetailResponse).hasFieldOrProperty("wishCount"),
+			() -> assertThat(itemDetailResponse).hasFieldOrProperty("viewCount"),
+			() -> assertThat(itemDetailResponse).hasFieldOrProperty("price"),
+			() -> assertThat(itemDetailResponse).hasFieldOrProperty("isInWishList"),
+			() -> assertThat(itemDetailResponse).hasFieldOrProperty("thumbnail"),
+			() -> assertThat(itemDetailResponse).hasFieldOrProperty("images")
 		);
 	}
 


### PR DESCRIPTION
## Issues
- #28 

## What is this PR? 👓
- 상품 상세페이지 조회 기능에 관한 PR입니다.

## Key changes 🔑
- 상품 상세페이지 조회 기능
- 상품 상세페이지 조회 테스트 
- `@Modifying` 어노테이션 옵션 삭제 
  - `clearAutomatically` 기능과 `flushAutomatically` 기능때문에 변경 감지가 안됐음, 어차피 변경감지 기능으로 인하여 flush됨으로 옵션 기능 삭제 
- 상품 수정 기능에 대한 오류가 있어서 해결
  - 썸네일 변경 안됨 -> `수정완료`
  - 이미지 추가 안됨 -> `수정완료`
  - 테스트 코드 실패 -> `수정완료`
