### PR TITLE
[feat] 판매내역 조회 기능

### DIFF
--- a/src/main/java/pie/tomato/tomatomarket/application/item/ItemService.java
+++ b/src/main/java/pie/tomato/tomatomarket/application/item/ItemService.java
@@ -19,7 +19,6 @@ import pie.tomato.tomatomarket.exception.BadRequestException;
 import pie.tomato.tomatomarket.exception.ErrorCode;
 import pie.tomato.tomatomarket.exception.ForbiddenException;
 import pie.tomato.tomatomarket.exception.NotFoundException;
-import pie.tomato.tomatomarket.exception.UnAuthorizedException;
 import pie.tomato.tomatomarket.infrastructure.persistence.category.CategoryRepository;
 import pie.tomato.tomatomarket.infrastructure.persistence.chatroom.ChatroomRepository;
 import pie.tomato.tomatomarket.infrastructure.persistence.image.ImageRepository;
@@ -182,23 +181,11 @@ public class ItemService {
 
 	public CustomSlice<SalesItemDetailResponse> salesItemDetails(
 		String status, Principal principal, int size, Long cursor) {
-		if (status.equalsIgnoreCase("null")) {
-			new UnAuthorizedException(ErrorCode.NOT_LOGIN);
-		}
-		ItemStatus findStatus = findStatus(status);
+		ItemStatus findStatus = ItemStatus.findStatus(status);
 		Slice<SalesItemDetailResponse> responses =
 			itemPaginationRepository.findByMemberIdAndStatus(principal, findStatus, size, cursor);
 		List<SalesItemDetailResponse> content = responses.getContent();
 		Long nextCursor = content.isEmpty() ? null : content.get(content.size() - 1).getItemId();
 		return new CustomSlice<>(content, nextCursor, responses.hasNext());
-	}
-
-	private ItemStatus findStatus(String status) {
-		if (status == "on_sale") {
-			return ItemStatus.ON_SALE;
-		} else if (status == "sold_out") {
-			return ItemStatus.SOLD_OUT;
-		}
-		return null;
 	}
 }

--- a/src/main/java/pie/tomato/tomatomarket/application/item/ItemService.java
+++ b/src/main/java/pie/tomato/tomatomarket/application/item/ItemService.java
@@ -19,19 +19,19 @@ import pie.tomato.tomatomarket.exception.BadRequestException;
 import pie.tomato.tomatomarket.exception.ErrorCode;
 import pie.tomato.tomatomarket.exception.ForbiddenException;
 import pie.tomato.tomatomarket.exception.NotFoundException;
-import pie.tomato.tomatomarket.infrastructure.persistence.CategoryRepository;
-import pie.tomato.tomatomarket.infrastructure.persistence.ChatroomRepository;
-import pie.tomato.tomatomarket.infrastructure.persistence.MemberRepository;
+import pie.tomato.tomatomarket.infrastructure.persistence.category.CategoryRepository;
+import pie.tomato.tomatomarket.infrastructure.persistence.chatroom.ChatroomRepository;
 import pie.tomato.tomatomarket.infrastructure.persistence.image.ImageRepository;
 import pie.tomato.tomatomarket.infrastructure.persistence.item.ItemPaginationRepository;
 import pie.tomato.tomatomarket.infrastructure.persistence.item.ItemRepository;
+import pie.tomato.tomatomarket.infrastructure.persistence.member.MemberRepository;
 import pie.tomato.tomatomarket.infrastructure.persistence.wish.WishRepository;
 import pie.tomato.tomatomarket.presentation.dto.CustomSlice;
-import pie.tomato.tomatomarket.presentation.request.item.ItemModifyRequest;
-import pie.tomato.tomatomarket.presentation.request.item.ItemRegisterRequest;
-import pie.tomato.tomatomarket.presentation.request.item.ItemStatusModifyRequest;
-import pie.tomato.tomatomarket.presentation.response.item.ItemDetailResponse;
-import pie.tomato.tomatomarket.presentation.response.item.ItemResponse;
+import pie.tomato.tomatomarket.presentation.item.request.ItemModifyRequest;
+import pie.tomato.tomatomarket.presentation.item.request.ItemRegisterRequest;
+import pie.tomato.tomatomarket.presentation.item.request.ItemStatusModifyRequest;
+import pie.tomato.tomatomarket.presentation.item.response.ItemDetailResponse;
+import pie.tomato.tomatomarket.presentation.item.response.ItemResponse;
 import pie.tomato.tomatomarket.presentation.support.Principal;
 
 @Service

--- a/src/main/java/pie/tomato/tomatomarket/application/member/MemberService.java
+++ b/src/main/java/pie/tomato/tomatomarket/application/member/MemberService.java
@@ -8,7 +8,7 @@ import pie.tomato.tomatomarket.domain.Member;
 import pie.tomato.tomatomarket.exception.BadRequestException;
 import pie.tomato.tomatomarket.exception.ErrorCode;
 import pie.tomato.tomatomarket.exception.NotFoundException;
-import pie.tomato.tomatomarket.infrastructure.persistence.MemberRepository;
+import pie.tomato.tomatomarket.infrastructure.persistence.member.MemberRepository;
 
 @Service
 @Transactional(readOnly = true)

--- a/src/main/java/pie/tomato/tomatomarket/application/oauth/AuthService.java
+++ b/src/main/java/pie/tomato/tomatomarket/application/oauth/AuthService.java
@@ -10,7 +10,7 @@ import pie.tomato.tomatomarket.exception.BadRequestException;
 import pie.tomato.tomatomarket.exception.ErrorCode;
 import pie.tomato.tomatomarket.exception.NotFoundException;
 import pie.tomato.tomatomarket.infrastructure.config.jwt.JwtProvider;
-import pie.tomato.tomatomarket.infrastructure.persistence.MemberRepository;
+import pie.tomato.tomatomarket.infrastructure.persistence.member.MemberRepository;
 
 @RequiredArgsConstructor
 @Service

--- a/src/main/java/pie/tomato/tomatomarket/application/wish/WishItemService.java
+++ b/src/main/java/pie/tomato/tomatomarket/application/wish/WishItemService.java
@@ -13,15 +13,15 @@ import pie.tomato.tomatomarket.domain.Wish;
 import pie.tomato.tomatomarket.domain.WishStatus;
 import pie.tomato.tomatomarket.exception.ErrorCode;
 import pie.tomato.tomatomarket.exception.NotFoundException;
-import pie.tomato.tomatomarket.infrastructure.persistence.MemberRepository;
 import pie.tomato.tomatomarket.infrastructure.persistence.item.ItemPaginationRepository;
 import pie.tomato.tomatomarket.infrastructure.persistence.item.ItemRepository;
+import pie.tomato.tomatomarket.infrastructure.persistence.member.MemberRepository;
 import pie.tomato.tomatomarket.infrastructure.persistence.wish.WishCategoryRepository;
 import pie.tomato.tomatomarket.infrastructure.persistence.wish.WishRepository;
 import pie.tomato.tomatomarket.presentation.dto.CustomSlice;
-import pie.tomato.tomatomarket.presentation.response.wish.CategoryWishListResponse;
-import pie.tomato.tomatomarket.presentation.response.wish.WishListResponse;
 import pie.tomato.tomatomarket.presentation.support.Principal;
+import pie.tomato.tomatomarket.presentation.wish.response.CategoryWishListResponse;
+import pie.tomato.tomatomarket.presentation.wish.response.WishListResponse;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/pie/tomato/tomatomarket/domain/Item.java
+++ b/src/main/java/pie/tomato/tomatomarket/domain/Item.java
@@ -17,7 +17,7 @@ import javax.persistence.ManyToOne;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import pie.tomato.tomatomarket.presentation.request.item.ItemModifyRequest;
+import pie.tomato.tomatomarket.presentation.item.request.ItemModifyRequest;
 
 @Entity
 @Getter

--- a/src/main/java/pie/tomato/tomatomarket/domain/ItemStatus.java
+++ b/src/main/java/pie/tomato/tomatomarket/domain/ItemStatus.java
@@ -23,4 +23,11 @@ public enum ItemStatus {
 			.findFirst()
 			.orElseThrow(() -> new BadRequestException(ErrorCode.INVALID_STATUS));
 	}
+
+	public static ItemStatus findStatus(String status) {
+		return Arrays.stream(ItemStatus.values())
+			.filter(itemStatus -> itemStatus.name().equalsIgnoreCase(status))
+			.findFirst()
+			.orElse(null);
+	}
 }

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/category/CategoryRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/category/CategoryRepository.java
@@ -1,4 +1,4 @@
-package pie.tomato.tomatomarket.infrastructure.persistence;
+package pie.tomato.tomatomarket.infrastructure.persistence.category;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/chatroom/ChatroomRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/chatroom/ChatroomRepository.java
@@ -1,4 +1,4 @@
-package pie.tomato.tomatomarket.infrastructure.persistence;
+package pie.tomato.tomatomarket.infrastructure.persistence.chatroom;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/item/ItemPaginationRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/item/ItemPaginationRepository.java
@@ -12,8 +12,11 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
+import pie.tomato.tomatomarket.domain.ItemStatus;
 import pie.tomato.tomatomarket.infrastructure.persistence.util.PaginationUtil;
 import pie.tomato.tomatomarket.presentation.item.response.ItemResponse;
+import pie.tomato.tomatomarket.presentation.item.response.SalesItemDetailResponse;
+import pie.tomato.tomatomarket.presentation.support.Principal;
 import pie.tomato.tomatomarket.presentation.wish.response.WishListResponse;
 
 @RequiredArgsConstructor
@@ -70,5 +73,26 @@ public class ItemPaginationRepository {
 			.limit(size + 1)
 			.fetch();
 		return PaginationUtil.checkLastPage(size, wishListResponse);
+	}
+
+	public Slice<SalesItemDetailResponse> findByMemberIdAndStatus(
+		Principal principal, ItemStatus status, int size, Long cursor) {
+		List<SalesItemDetailResponse> responses = queryFactory.select(Projections.fields(SalesItemDetailResponse.class,
+				item.id.as("itemId"),
+				item.thumbnail.as("thumbnailUrl"),
+				item.title,
+				item.region.as("tradingRegion"),
+				item.createdAt,
+				item.price,
+				item.status))
+			.from(item)
+			.where(
+				itemRepository.lessThanItemId(cursor),
+				itemRepository.equalMemberId(principal.getMemberId()),
+				itemRepository.findStatus(status))
+			.orderBy(item.createdAt.desc())
+			.limit(size + 1)
+			.fetch();
+		return PaginationUtil.checkLastPage(size, responses);
 	}
 }

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/item/ItemPaginationRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/item/ItemPaginationRepository.java
@@ -13,8 +13,8 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
 import pie.tomato.tomatomarket.infrastructure.persistence.util.PaginationUtil;
-import pie.tomato.tomatomarket.presentation.response.item.ItemResponse;
-import pie.tomato.tomatomarket.presentation.response.wish.WishListResponse;
+import pie.tomato.tomatomarket.presentation.item.response.ItemResponse;
+import pie.tomato.tomatomarket.presentation.wish.response.WishListResponse;
 
 @RequiredArgsConstructor
 @Repository

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/item/ItemPaginationRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/item/ItemPaginationRepository.java
@@ -52,7 +52,7 @@ public class ItemPaginationRepository {
 	public Slice<WishListResponse> findByMemberIdAndCategoryId(Long memberId, Long categoryId,
 		int size, Long cursor) {
 		List<WishListResponse> wishListResponse = queryFactory.select(Projections.fields(WishListResponse.class,
-				item.id.as("cursor"),
+				item.id.as("itemId"),
 				item.thumbnail.as("thumbnailUrl"),
 				item.title,
 				item.region.as("tradingRegion"),

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/item/ItemRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/item/ItemRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.querydsl.core.types.dsl.BooleanExpression;
 
 import pie.tomato.tomatomarket.domain.Item;
+import pie.tomato.tomatomarket.domain.ItemStatus;
 
 public interface ItemRepository extends JpaRepository<Item, Long> {
 
@@ -44,5 +45,15 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
 			return null;
 		}
 		return item.member.id.eq(memberId);
+	}
+
+	default BooleanExpression findStatus(ItemStatus status) {
+		if (status == null) {
+			return null;
+		} else if (status.equals(ItemStatus.SOLD_OUT)) {
+			return item.status.eq(status);
+		} else {
+			return item.status.ne(ItemStatus.SOLD_OUT);
+		}
 	}
 }

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/member/MemberRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/member/MemberRepository.java
@@ -1,4 +1,4 @@
-package pie.tomato.tomatomarket.infrastructure.persistence;
+package pie.tomato.tomatomarket.infrastructure.persistence.member;
 
 import java.util.Optional;
 

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/wish/WishCategoryRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/wish/WishCategoryRepository.java
@@ -12,8 +12,8 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
-import pie.tomato.tomatomarket.presentation.response.wish.CategoryWishListResponse;
 import pie.tomato.tomatomarket.presentation.support.Principal;
+import pie.tomato.tomatomarket.presentation.wish.response.CategoryWishListResponse;
 
 @Repository
 @RequiredArgsConstructor

--- a/src/main/java/pie/tomato/tomatomarket/presentation/auth/AuthController.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/auth/AuthController.java
@@ -1,4 +1,4 @@
-package pie.tomato.tomatomarket.presentation;
+package pie.tomato.tomatomarket.presentation.auth;
 
 import static org.springframework.http.HttpStatus.*;
 
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 import pie.tomato.tomatomarket.application.oauth.AuthService;
-import pie.tomato.tomatomarket.presentation.response.oauth.LoginResponse;
+import pie.tomato.tomatomarket.presentation.auth.response.LoginResponse;
 
 @RequiredArgsConstructor
 @RestController

--- a/src/main/java/pie/tomato/tomatomarket/presentation/auth/response/LoginResponse.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/auth/response/LoginResponse.java
@@ -1,4 +1,4 @@
-package pie.tomato.tomatomarket.presentation.response.oauth;
+package pie.tomato.tomatomarket.presentation.auth.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/pie/tomato/tomatomarket/presentation/item/ItemController.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/item/ItemController.java
@@ -26,18 +26,17 @@ import pie.tomato.tomatomarket.presentation.item.request.ItemRegisterRequest;
 import pie.tomato.tomatomarket.presentation.item.request.ItemStatusModifyRequest;
 import pie.tomato.tomatomarket.presentation.item.response.ItemDetailResponse;
 import pie.tomato.tomatomarket.presentation.item.response.ItemResponse;
-import pie.tomato.tomatomarket.presentation.item.response.SalesItemDetailResponse;
 import pie.tomato.tomatomarket.presentation.support.AuthPrincipal;
 import pie.tomato.tomatomarket.presentation.support.Principal;
 
 @RestController
-@RequestMapping("/api")
+@RequestMapping("/api/items")
 @RequiredArgsConstructor
 public class ItemController {
 
 	private final ItemService itemService;
 
-	@PostMapping(value = "/items", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	@PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	public ResponseEntity<Void> register(@RequestPart("item") ItemRegisterRequest itemRegisterRequest,
 		@RequestPart(value = "images", required = false) List<MultipartFile> itemImages,
 		@RequestPart("thumbnailImage") MultipartFile thumbnail,
@@ -46,7 +45,7 @@ public class ItemController {
 		return ResponseEntity.status(HttpStatus.CREATED).build();
 	}
 
-	@PutMapping("/items/{itemId}/status")
+	@PutMapping("/{itemId}/status")
 	public ResponseEntity<Void> modifyStatus(@PathVariable Long itemId,
 		@AuthPrincipal Principal principal,
 		@RequestBody ItemStatusModifyRequest request) {
@@ -54,7 +53,7 @@ public class ItemController {
 		return ResponseEntity.ok().build();
 	}
 
-	@GetMapping("/items")
+	@GetMapping()
 	public ResponseEntity<CustomSlice<ItemResponse>> findAll(@RequestParam String region,
 		@RequestParam(required = false, defaultValue = "10") int size,
 		@RequestParam(required = false) Long cursor,
@@ -62,7 +61,7 @@ public class ItemController {
 		return ResponseEntity.ok().body(itemService.findAll(region, size, cursor, categoryId));
 	}
 
-	@PatchMapping("/items/{itemId}")
+	@PatchMapping("/{itemId}")
 	public ResponseEntity<Void> modifyItem(@PathVariable Long itemId,
 		@AuthPrincipal Principal principal,
 		@RequestPart("item") ItemModifyRequest modifyRequest,
@@ -72,23 +71,14 @@ public class ItemController {
 		return ResponseEntity.ok().build();
 	}
 
-	@DeleteMapping("/items/{itemId}")
+	@DeleteMapping("/{itemId}")
 	public ResponseEntity<Void> deleteItem(@PathVariable Long itemId, @AuthPrincipal Principal principal) {
 		itemService.deleteItem(itemId, principal);
 		return ResponseEntity.ok().build();
 	}
 
-	@GetMapping("/items/{itemId}")
+	@GetMapping("/{itemId}")
 	public ResponseEntity<ItemDetailResponse> itemDetails(@PathVariable Long itemId) {
 		return ResponseEntity.ok().body(itemService.itemDetails(itemId));
-	}
-
-	@GetMapping("/sales/history")
-	public ResponseEntity<CustomSlice<SalesItemDetailResponse>> salesItemDetails(
-		@AuthPrincipal Principal principal,
-		@RequestParam(required = false) String status,
-		@RequestParam(required = false, defaultValue = "10") int size,
-		@RequestParam(required = false) Long cursor) {
-		return ResponseEntity.ok().body(itemService.salesItemDetails(status, principal, size, cursor));
 	}
 }

--- a/src/main/java/pie/tomato/tomatomarket/presentation/item/ItemController.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/item/ItemController.java
@@ -31,13 +31,13 @@ import pie.tomato.tomatomarket.presentation.support.AuthPrincipal;
 import pie.tomato.tomatomarket.presentation.support.Principal;
 
 @RestController
-@RequestMapping("/api/items")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class ItemController {
 
 	private final ItemService itemService;
 
-	@PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	@PostMapping(value = "/items", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	public ResponseEntity<Void> register(@RequestPart("item") ItemRegisterRequest itemRegisterRequest,
 		@RequestPart(value = "images", required = false) List<MultipartFile> itemImages,
 		@RequestPart("thumbnailImage") MultipartFile thumbnail,
@@ -46,7 +46,7 @@ public class ItemController {
 		return ResponseEntity.status(HttpStatus.CREATED).build();
 	}
 
-	@PutMapping("/{itemId}/status")
+	@PutMapping("/items/{itemId}/status")
 	public ResponseEntity<Void> modifyStatus(@PathVariable Long itemId,
 		@AuthPrincipal Principal principal,
 		@RequestBody ItemStatusModifyRequest request) {
@@ -54,7 +54,7 @@ public class ItemController {
 		return ResponseEntity.ok().build();
 	}
 
-	@GetMapping
+	@GetMapping("/items")
 	public ResponseEntity<CustomSlice<ItemResponse>> findAll(@RequestParam String region,
 		@RequestParam(required = false, defaultValue = "10") int size,
 		@RequestParam(required = false) Long cursor,
@@ -62,7 +62,7 @@ public class ItemController {
 		return ResponseEntity.ok().body(itemService.findAll(region, size, cursor, categoryId));
 	}
 
-	@PatchMapping("/{itemId}")
+	@PatchMapping("/items/{itemId}")
 	public ResponseEntity<Void> modifyItem(@PathVariable Long itemId,
 		@AuthPrincipal Principal principal,
 		@RequestPart("item") ItemModifyRequest modifyRequest,
@@ -72,18 +72,18 @@ public class ItemController {
 		return ResponseEntity.ok().build();
 	}
 
-	@DeleteMapping("/{itemId}")
+	@DeleteMapping("/items/{itemId}")
 	public ResponseEntity<Void> deleteItem(@PathVariable Long itemId, @AuthPrincipal Principal principal) {
 		itemService.deleteItem(itemId, principal);
 		return ResponseEntity.ok().build();
 	}
 
-	@GetMapping("/{itemId}")
+	@GetMapping("/items/{itemId}")
 	public ResponseEntity<ItemDetailResponse> itemDetails(@PathVariable Long itemId) {
 		return ResponseEntity.ok().body(itemService.itemDetails(itemId));
 	}
 
-	@GetMapping("/api/sales/history")
+	@GetMapping("/sales/history")
 	public ResponseEntity<CustomSlice<SalesItemDetailResponse>> salesItemDetails(
 		@AuthPrincipal Principal principal,
 		@RequestParam(required = false) String status,

--- a/src/main/java/pie/tomato/tomatomarket/presentation/item/ItemController.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/item/ItemController.java
@@ -26,6 +26,7 @@ import pie.tomato.tomatomarket.presentation.item.request.ItemRegisterRequest;
 import pie.tomato.tomatomarket.presentation.item.request.ItemStatusModifyRequest;
 import pie.tomato.tomatomarket.presentation.item.response.ItemDetailResponse;
 import pie.tomato.tomatomarket.presentation.item.response.ItemResponse;
+import pie.tomato.tomatomarket.presentation.item.response.SalesItemDetailResponse;
 import pie.tomato.tomatomarket.presentation.support.AuthPrincipal;
 import pie.tomato.tomatomarket.presentation.support.Principal;
 
@@ -82,4 +83,12 @@ public class ItemController {
 		return ResponseEntity.ok().body(itemService.itemDetails(itemId));
 	}
 
+	@GetMapping("/api/sales/history")
+	public ResponseEntity<CustomSlice<SalesItemDetailResponse>> salesItemDetails(
+		@AuthPrincipal Principal principal,
+		@RequestParam(required = false) String status,
+		@RequestParam(required = false, defaultValue = "10") int size,
+		@RequestParam(required = false) Long cursor) {
+		return ResponseEntity.ok().body(itemService.salesItemDetails(status, principal, size, cursor));
+	}
 }

--- a/src/main/java/pie/tomato/tomatomarket/presentation/item/ItemController.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/item/ItemController.java
@@ -1,4 +1,4 @@
-package pie.tomato.tomatomarket.presentation;
+package pie.tomato.tomatomarket.presentation.item;
 
 import java.util.List;
 
@@ -21,11 +21,11 @@ import org.springframework.web.multipart.MultipartFile;
 import lombok.RequiredArgsConstructor;
 import pie.tomato.tomatomarket.application.item.ItemService;
 import pie.tomato.tomatomarket.presentation.dto.CustomSlice;
-import pie.tomato.tomatomarket.presentation.request.item.ItemModifyRequest;
-import pie.tomato.tomatomarket.presentation.request.item.ItemRegisterRequest;
-import pie.tomato.tomatomarket.presentation.request.item.ItemStatusModifyRequest;
-import pie.tomato.tomatomarket.presentation.response.item.ItemDetailResponse;
-import pie.tomato.tomatomarket.presentation.response.item.ItemResponse;
+import pie.tomato.tomatomarket.presentation.item.request.ItemModifyRequest;
+import pie.tomato.tomatomarket.presentation.item.request.ItemRegisterRequest;
+import pie.tomato.tomatomarket.presentation.item.request.ItemStatusModifyRequest;
+import pie.tomato.tomatomarket.presentation.item.response.ItemDetailResponse;
+import pie.tomato.tomatomarket.presentation.item.response.ItemResponse;
 import pie.tomato.tomatomarket.presentation.support.AuthPrincipal;
 import pie.tomato.tomatomarket.presentation.support.Principal;
 
@@ -81,4 +81,5 @@ public class ItemController {
 	public ResponseEntity<ItemDetailResponse> itemDetails(@PathVariable Long itemId) {
 		return ResponseEntity.ok().body(itemService.itemDetails(itemId));
 	}
+
 }

--- a/src/main/java/pie/tomato/tomatomarket/presentation/item/request/ItemModifyRequest.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/item/request/ItemModifyRequest.java
@@ -1,4 +1,4 @@
-package pie.tomato.tomatomarket.presentation.request.item;
+package pie.tomato.tomatomarket.presentation.item.request;
 
 import java.util.List;
 

--- a/src/main/java/pie/tomato/tomatomarket/presentation/item/request/ItemRegisterRequest.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/item/request/ItemRegisterRequest.java
@@ -1,4 +1,4 @@
-package pie.tomato.tomatomarket.presentation.request.item;
+package pie.tomato.tomatomarket.presentation.item.request;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/pie/tomato/tomatomarket/presentation/item/request/ItemStatusModifyRequest.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/item/request/ItemStatusModifyRequest.java
@@ -1,4 +1,4 @@
-package pie.tomato.tomatomarket.presentation.request.item;
+package pie.tomato.tomatomarket.presentation.item.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/pie/tomato/tomatomarket/presentation/item/response/ItemDetailResponse.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/item/response/ItemDetailResponse.java
@@ -1,4 +1,4 @@
-package pie.tomato.tomatomarket.presentation.response.item;
+package pie.tomato.tomatomarket.presentation.item.response;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/src/main/java/pie/tomato/tomatomarket/presentation/item/response/ItemResponse.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/item/response/ItemResponse.java
@@ -1,4 +1,4 @@
-package pie.tomato.tomatomarket.presentation.response.wish;
+package pie.tomato.tomatomarket.presentation.item.response;
 
 import java.time.LocalDateTime;
 
@@ -6,7 +6,7 @@ import lombok.Getter;
 import pie.tomato.tomatomarket.domain.ItemStatus;
 
 @Getter
-public class WishListResponse {
+public class ItemResponse {
 
 	private Long itemId;
 	private String thumbnailUrl;
@@ -15,7 +15,7 @@ public class WishListResponse {
 	private LocalDateTime createdAt;
 	private Long price;
 	private ItemStatus status;
-	private Long wishCount;
 	private Long chatCount;
-	private String sellerId;
+	private Long wishCount;
+	private String isSeller;
 }

--- a/src/main/java/pie/tomato/tomatomarket/presentation/item/response/SalesItemDetailResponse.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/item/response/SalesItemDetailResponse.java
@@ -1,8 +1,9 @@
-package pie.tomato.tomatomarket.presentation.sales.response;
+package pie.tomato.tomatomarket.presentation.item.response;
 
 import java.time.LocalDateTime;
 
 import lombok.Getter;
+import pie.tomato.tomatomarket.domain.ItemStatus;
 
 @Getter
 public class SalesItemDetailResponse {
@@ -13,5 +14,5 @@ public class SalesItemDetailResponse {
 	private String tradingRegion;
 	private LocalDateTime createdAt;
 	private Long price;
-	private String status;
+	private ItemStatus status;
 }

--- a/src/main/java/pie/tomato/tomatomarket/presentation/member/MemberController.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/member/MemberController.java
@@ -1,4 +1,4 @@
-package pie.tomato.tomatomarket.presentation;
+package pie.tomato.tomatomarket.presentation.member;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 import pie.tomato.tomatomarket.application.member.MemberService;
-import pie.tomato.tomatomarket.presentation.request.member.NicknameModifyRequest;
+import pie.tomato.tomatomarket.presentation.member.request.NicknameModifyRequest;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/pie/tomato/tomatomarket/presentation/member/request/NicknameModifyRequest.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/member/request/NicknameModifyRequest.java
@@ -1,4 +1,4 @@
-package pie.tomato.tomatomarket.presentation.request.member;
+package pie.tomato.tomatomarket.presentation.member.request;
 
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/pie/tomato/tomatomarket/presentation/sales/SalesItemController.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/sales/SalesItemController.java
@@ -1,0 +1,31 @@
+package pie.tomato.tomatomarket.presentation.sales;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import pie.tomato.tomatomarket.application.item.ItemService;
+import pie.tomato.tomatomarket.presentation.dto.CustomSlice;
+import pie.tomato.tomatomarket.presentation.item.response.SalesItemDetailResponse;
+import pie.tomato.tomatomarket.presentation.support.AuthPrincipal;
+import pie.tomato.tomatomarket.presentation.support.Principal;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/sales")
+public class SalesItemController {
+
+	private final ItemService itemService;
+
+	@GetMapping("/history")
+	public ResponseEntity<CustomSlice<SalesItemDetailResponse>> salesItemDetails(
+		@AuthPrincipal Principal principal,
+		@RequestParam(required = false) String status,
+		@RequestParam(required = false, defaultValue = "10") int size,
+		@RequestParam(required = false) Long cursor) {
+		return ResponseEntity.ok().body(itemService.salesItemDetails(status, principal, size, cursor));
+	}
+}

--- a/src/main/java/pie/tomato/tomatomarket/presentation/sales/response/SalesItemDetailResponse.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/sales/response/SalesItemDetailResponse.java
@@ -1,0 +1,17 @@
+package pie.tomato.tomatomarket.presentation.sales.response;
+
+import java.time.LocalDateTime;
+
+import lombok.Getter;
+
+@Getter
+public class SalesItemDetailResponse {
+
+	private Long itemId;
+	private String thumbnailUrl;
+	private String title;
+	private String tradingRegion;
+	private LocalDateTime createdAt;
+	private Long price;
+	private String status;
+}

--- a/src/main/java/pie/tomato/tomatomarket/presentation/wish/WishItemController.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/wish/WishItemController.java
@@ -1,4 +1,4 @@
-package pie.tomato.tomatomarket.presentation;
+package pie.tomato.tomatomarket.presentation.wish;
 
 import java.util.List;
 
@@ -13,10 +13,10 @@ import org.springframework.web.bind.annotation.RestController;
 import lombok.RequiredArgsConstructor;
 import pie.tomato.tomatomarket.application.wish.WishItemService;
 import pie.tomato.tomatomarket.presentation.dto.CustomSlice;
-import pie.tomato.tomatomarket.presentation.response.wish.CategoryWishListResponse;
-import pie.tomato.tomatomarket.presentation.response.wish.WishListResponse;
 import pie.tomato.tomatomarket.presentation.support.AuthPrincipal;
 import pie.tomato.tomatomarket.presentation.support.Principal;
+import pie.tomato.tomatomarket.presentation.wish.response.CategoryWishListResponse;
+import pie.tomato.tomatomarket.presentation.wish.response.WishListResponse;
 
 @RestController
 @RequestMapping("/api/wishes")

--- a/src/main/java/pie/tomato/tomatomarket/presentation/wish/response/CategoryWishListResponse.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/wish/response/CategoryWishListResponse.java
@@ -1,4 +1,4 @@
-package pie.tomato.tomatomarket.presentation.response.wish;
+package pie.tomato.tomatomarket.presentation.wish.response;
 
 import lombok.Getter;
 

--- a/src/main/java/pie/tomato/tomatomarket/presentation/wish/response/WishListResponse.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/wish/response/WishListResponse.java
@@ -1,4 +1,4 @@
-package pie.tomato.tomatomarket.presentation.response.item;
+package pie.tomato.tomatomarket.presentation.wish.response;
 
 import java.time.LocalDateTime;
 
@@ -6,7 +6,7 @@ import lombok.Getter;
 import pie.tomato.tomatomarket.domain.ItemStatus;
 
 @Getter
-public class ItemResponse {
+public class WishListResponse {
 
 	private Long itemId;
 	private String thumbnailUrl;
@@ -15,7 +15,7 @@ public class ItemResponse {
 	private LocalDateTime createdAt;
 	private Long price;
 	private ItemStatus status;
-	private Long chatCount;
 	private Long wishCount;
-	private String isSeller;
+	private Long chatCount;
+	private String sellerId;
 }

--- a/src/test/java/pie/tomato/tomatomarket/application/ItemServiceTest.java
+++ b/src/test/java/pie/tomato/tomatomarket/application/ItemServiceTest.java
@@ -26,11 +26,11 @@ import pie.tomato.tomatomarket.domain.ItemStatus;
 import pie.tomato.tomatomarket.domain.Member;
 import pie.tomato.tomatomarket.infrastructure.persistence.image.ImageRepository;
 import pie.tomato.tomatomarket.presentation.dto.CustomSlice;
-import pie.tomato.tomatomarket.presentation.request.item.ItemModifyRequest;
-import pie.tomato.tomatomarket.presentation.request.item.ItemRegisterRequest;
-import pie.tomato.tomatomarket.presentation.request.item.ItemStatusModifyRequest;
-import pie.tomato.tomatomarket.presentation.response.item.ItemDetailResponse;
-import pie.tomato.tomatomarket.presentation.response.item.ItemResponse;
+import pie.tomato.tomatomarket.presentation.item.request.ItemModifyRequest;
+import pie.tomato.tomatomarket.presentation.item.request.ItemRegisterRequest;
+import pie.tomato.tomatomarket.presentation.item.request.ItemStatusModifyRequest;
+import pie.tomato.tomatomarket.presentation.item.response.ItemDetailResponse;
+import pie.tomato.tomatomarket.presentation.item.response.ItemResponse;
 import pie.tomato.tomatomarket.presentation.support.Principal;
 import pie.tomato.tomatomarket.support.SupportRepository;
 

--- a/src/test/java/pie/tomato/tomatomarket/application/ItemServiceTest.java
+++ b/src/test/java/pie/tomato/tomatomarket/application/ItemServiceTest.java
@@ -31,6 +31,7 @@ import pie.tomato.tomatomarket.presentation.item.request.ItemRegisterRequest;
 import pie.tomato.tomatomarket.presentation.item.request.ItemStatusModifyRequest;
 import pie.tomato.tomatomarket.presentation.item.response.ItemDetailResponse;
 import pie.tomato.tomatomarket.presentation.item.response.ItemResponse;
+import pie.tomato.tomatomarket.presentation.item.response.SalesItemDetailResponse;
 import pie.tomato.tomatomarket.presentation.support.Principal;
 import pie.tomato.tomatomarket.support.SupportRepository;
 
@@ -280,6 +281,55 @@ class ItemServiceTest {
 			() -> assertThat(itemDetailResponse).hasFieldOrProperty("images"),
 			() -> assertThat(itemDetailResponse.isInWishList()).isFalse()
 		);
+	}
+
+	@DisplayName("판매내역 조회에 성공한다. : 전체조회")
+	@Test
+	void salesItemDetails_V1() {
+		// given
+		Category category = setupCategory();
+		Member member = setupMember();
+		Principal principal = setPrincipal(member);
+
+		Item item1 = supportRepository.save(new Item("1번", "내용1", 3000L, "thumbnail", ItemStatus.ON_SALE,
+			"역삼1동", 0L, 0L, 0L, LocalDateTime.now(), member, category));
+		Item item2 = supportRepository.save(new Item("2번", "내용2", 3000L, "thumbnail", ItemStatus.RESERVED,
+			"역삼1동", 0L, 0L, 0L, LocalDateTime.now(), member, category));
+		Item item3 = supportRepository.save(new Item("3번", "내용3", 3000L, "thumbnail", ItemStatus.SOLD_OUT,
+			"역삼1동", 0L, 0L, 0L, LocalDateTime.now(), member, category));
+
+		// when
+		CustomSlice<SalesItemDetailResponse> salesItemDetailResponse =
+			itemService.salesItemDetails("all", principal, 10, null);
+
+		// then
+		assertThat(salesItemDetailResponse.getContents().size()).isEqualTo(3);
+	}
+
+	@DisplayName("판매내역 조회에 성공한다. : 판매중(+예약중)만 조회, 판매완료만 조회")
+	@Test
+	void salesItemDetails_V2() {
+		// given
+		Category category = setupCategory();
+		Member member = setupMember();
+		Principal principal = setPrincipal(member);
+
+		Item item1 = supportRepository.save(new Item("1번", "내용1", 3000L, "thumbnail", ItemStatus.ON_SALE,
+			"역삼1동", 0L, 0L, 0L, LocalDateTime.now(), member, category));
+		Item item2 = supportRepository.save(new Item("2번", "내용2", 3000L, "thumbnail", ItemStatus.RESERVED,
+			"역삼1동", 0L, 0L, 0L, LocalDateTime.now(), member, category));
+		Item item3 = supportRepository.save(new Item("3번", "내용3", 3000L, "thumbnail", ItemStatus.SOLD_OUT,
+			"역삼1동", 0L, 0L, 0L, LocalDateTime.now(), member, category));
+
+		// when
+		CustomSlice<SalesItemDetailResponse> salesItemDetailResponse1 =
+			itemService.salesItemDetails("on_sale", principal, 10, null);
+		CustomSlice<SalesItemDetailResponse> salesItemDetailResponse2 = itemService.salesItemDetails(
+			"sold_out", principal, 10, null);
+
+		// then
+		assertThat(salesItemDetailResponse1.getContents().size()).isEqualTo(2);
+		assertThat(salesItemDetailResponse2.getContents().size()).isEqualTo(1);
 	}
 
 	private ItemRegisterRequest createItemRegisterRequest(Category category) {

--- a/src/test/java/pie/tomato/tomatomarket/application/ItemServiceTest.java
+++ b/src/test/java/pie/tomato/tomatomarket/application/ItemServiceTest.java
@@ -314,11 +314,11 @@ class ItemServiceTest {
 		Member member = setupMember();
 		Principal principal = setPrincipal(member);
 
-		Item item1 = supportRepository.save(new Item("1번", "내용1", 3000L, "thumbnail", ItemStatus.ON_SALE,
+		supportRepository.save(new Item("1번", "내용1", 3000L, "thumbnail", ItemStatus.ON_SALE,
 			"역삼1동", 0L, 0L, 0L, LocalDateTime.now(), member, category));
-		Item item2 = supportRepository.save(new Item("2번", "내용2", 3000L, "thumbnail", ItemStatus.RESERVED,
+		supportRepository.save(new Item("2번", "내용2", 3000L, "thumbnail", ItemStatus.RESERVED,
 			"역삼1동", 0L, 0L, 0L, LocalDateTime.now(), member, category));
-		Item item3 = supportRepository.save(new Item("3번", "내용3", 3000L, "thumbnail", ItemStatus.SOLD_OUT,
+		supportRepository.save(new Item("3번", "내용3", 3000L, "thumbnail", ItemStatus.SOLD_OUT,
 			"역삼1동", 0L, 0L, 0L, LocalDateTime.now(), member, category));
 
 		// when
@@ -328,8 +328,10 @@ class ItemServiceTest {
 			"sold_out", principal, 10, null);
 
 		// then
-		assertThat(salesItemDetailResponse1.getContents().size()).isEqualTo(2);
-		assertThat(salesItemDetailResponse2.getContents().size()).isEqualTo(1);
+		assertAll(
+			() -> assertThat(salesItemDetailResponse1.getContents().size()).isEqualTo(2),
+			() -> assertThat(salesItemDetailResponse2.getContents().size()).isEqualTo(1)
+		);
 	}
 
 	private ItemRegisterRequest createItemRegisterRequest(Category category) {

--- a/src/test/java/pie/tomato/tomatomarket/application/WishItemServiceTest.java
+++ b/src/test/java/pie/tomato/tomatomarket/application/WishItemServiceTest.java
@@ -18,9 +18,9 @@ import pie.tomato.tomatomarket.domain.Item;
 import pie.tomato.tomatomarket.domain.ItemStatus;
 import pie.tomato.tomatomarket.domain.Member;
 import pie.tomato.tomatomarket.presentation.dto.CustomSlice;
-import pie.tomato.tomatomarket.presentation.response.wish.CategoryWishListResponse;
-import pie.tomato.tomatomarket.presentation.response.wish.WishListResponse;
 import pie.tomato.tomatomarket.presentation.support.Principal;
+import pie.tomato.tomatomarket.presentation.wish.response.CategoryWishListResponse;
+import pie.tomato.tomatomarket.presentation.wish.response.WishListResponse;
 import pie.tomato.tomatomarket.support.SupportRepository;
 
 @SpringBootTest

--- a/src/test/java/pie/tomato/tomatomarket/application/unit/AuthServiceTest.java
+++ b/src/test/java/pie/tomato/tomatomarket/application/unit/AuthServiceTest.java
@@ -17,7 +17,7 @@ import pie.tomato.tomatomarket.application.oauth.KakaoClient;
 import pie.tomato.tomatomarket.domain.OAuthUser;
 import pie.tomato.tomatomarket.exception.BadRequestException;
 import pie.tomato.tomatomarket.exception.ErrorCode;
-import pie.tomato.tomatomarket.infrastructure.persistence.MemberRepository;
+import pie.tomato.tomatomarket.infrastructure.persistence.member.MemberRepository;
 
 @SpringBootTest
 @Transactional


### PR DESCRIPTION
## Issues
- #36 

## What is this PR? 👓
판매내역 조회 기능에 대한 PR입니다.

## Key changes 🔑
- 패키지 구조를 변경했습니다.
- 판매내역 조회
  - 판매내역 전체 조회
  - `판매중 (+ 예약중)` 인 상품 판매내역 조회
  - `판매완료`인 상품 판매내역 조회
- 판매내역 조회 테스트
  - 판매내역 `전체` 조회 테스트
  - `판매중`인 상품 판매내역 조회 테스트
  - `판매완료`인 상품 판매내역 조회 테스트
- QueryDsl을 이용해 판매내역 조회 기능을 구현했습니다. 
## 📖 공부하면서 배웠던 것
### Enum의 비교는 ==일까 equals()일까 ?
![image](https://github.com/pie2457/Tomato-market/assets/104147789/96f6fd4d-523f-4958-ae7e-1102f1eab1b6)
enum의 equals()메서드를 먼저 살펴보니 내부에는 결국 == 연산자로 비교하고 있었다. 
즉, **enum 상수들끼리 비교할 때는 equals()로 비교하나 == 으로 비교하나 똑같다**는 뜻인데, 
내가 아는 ==은 동일성으로 두 개의 인스턴스가 주소값이 같다는 것이고,
equals()는 동등성으로 두 개의 인스턴스가 주소값은 다르지만 같은 value를 가지고 있는걸 의미했다.
분명 ==과 equals는 용도와 의미가 다른데 왜 같이 쓰는지 이해가가질 않아 찾아보니,
![image](https://github.com/pie2457/Tomato-market/assets/104147789/5dfc4262-f302-49e8-b47a-dd2af83bd329)
자바 공식 문서에 따르면 **enum 상수의 인스턴스는 딱 1개이기 때문에, 비교하려는 두 객체 중 적어도 하나가 enum의 상수라면 equals()대신 == 연산자로 비교할 수 있다**라고 되어있다! 
### 결론 : 싱글톤을 보장하는 enum이기 때문에 동일성과 동등성을 비교할 필요가 없게 된것이다.
