### PR TITLE
[feat] 지역(동네) 삭제 기능

### DIFF
--- a/src/main/java/pie/tomato/tomatomarket/application/memberTown/MemberTownService.java
+++ b/src/main/java/pie/tomato/tomatomarket/application/memberTown/MemberTownService.java
@@ -29,7 +29,7 @@ import pie.tomato.tomatomarket.presentation.support.Principal;
 @RequiredArgsConstructor
 public class MemberTownService {
 
-	public static final int MEMBER_TOWN_MAXIMUM_SIZE = 1;
+	public static final int MEMBER_TOWN_MINIMUM_SIZE = 1;
 
 	private final MemberTownRepository memberTownRepository;
 	private final RegionRepository regionRepository;
@@ -38,7 +38,8 @@ public class MemberTownService {
 
 	@Transactional
 	public void addMemberTown(Principal principal, AddMemberTownRequest memberTownRequest) {
-		Member member = getMember(principal);
+		Member member = memberRepository.findById(principal.getMemberId())
+			.orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_MEMBER));
 		Region region = regionRepository.findById(memberTownRequest.getAddressId())
 			.orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_REGION));
 
@@ -58,18 +59,21 @@ public class MemberTownService {
 			throw new BadRequestException(ErrorCode.ALREADY_ADDRESS);
 		}
 
-		if (memberTowns.size() > MEMBER_TOWN_MAXIMUM_SIZE) {
+		if (memberTowns.size() > MEMBER_TOWN_MINIMUM_SIZE) {
+			changeIsSelectedFalse(memberTowns, memberTownRequest.getAddressId());
 			throw new BadRequestException(ErrorCode.MAXIMUM_MEMBER_TOWN_SIZE);
 		}
 	}
 
-	private List<MemberTown> getMemberTowns(Principal principal) {
-		return memberTownRepository.findAllByMemberId(principal.getMemberId());
+	private void changeIsSelectedFalse(List<MemberTown> memberTowns, Long addressId) {
+		memberTowns.stream()
+			.filter(memberTown -> !memberTown.isSameRegionId(addressId))
+			.forEach(MemberTown::changeIsSelectedFalse);
 	}
 
-	private Member getMember(Principal principal) {
-		return memberRepository.findById(principal.getMemberId())
-			.orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_MEMBER));
+	private List<MemberTown> getMemberTowns(Principal principal) {
+		return memberTownRepository.findAllByMemberId(principal.getMemberId())
+			.orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_MEMBER_TOWN));
 	}
 
 	@Transactional
@@ -79,9 +83,7 @@ public class MemberTownService {
 		MemberTown selectMemberTown = getMemberTown(selectMemberTownRequest, memberTowns);
 		selectMemberTown.changeIsSelectedTrue();
 
-		memberTowns.stream()
-			.filter(memberTown -> !memberTown.isSameRegionId(selectMemberTown.getId()))
-			.forEach(MemberTown::changeIsSelectedFalse);
+		changeIsSelectedFalse(memberTowns, selectMemberTown.getId());
 	}
 
 	private MemberTown getMemberTown(SelectMemberTownRequest selectMemberTownRequest,
@@ -93,8 +95,8 @@ public class MemberTownService {
 	}
 
 	public CustomSlice<MemberTownListResponse> findAll(String addressName, int size, Long cursor) {
-		Slice<MemberTownListResponse> responses = memberTownPaginationRepository.findByAddressName(addressName,
-			size, cursor);
+		Slice<MemberTownListResponse> responses =
+			memberTownPaginationRepository.findByAddressName(addressName, size, cursor);
 		List<MemberTownListResponse> content = responses.getContent();
 
 		Long nextCursor = content.isEmpty() ? null : content.get(content.size() - 1).getAddressId();

--- a/src/main/java/pie/tomato/tomatomarket/application/memberTown/MemberTownService.java
+++ b/src/main/java/pie/tomato/tomatomarket/application/memberTown/MemberTownService.java
@@ -55,13 +55,16 @@ public class MemberTownService {
 		Optional<MemberTown> duplicated = memberTowns.stream()
 			.filter(memberTown -> memberTown.isSameRegionId(memberTownRequest.getAddressId()))
 			.findAny();
+		if (memberTowns.size() == MEMBER_TOWN_MINIMUM_SIZE) {
+			changeIsSelectedFalse(memberTowns, memberTownRequest.getAddressId());
+			return;
+		}
 
 		if (duplicated.isPresent()) {
 			throw new BadRequestException(ErrorCode.ALREADY_ADDRESS);
 		}
 
 		if (memberTowns.size() > MEMBER_TOWN_MINIMUM_SIZE) {
-			changeIsSelectedFalse(memberTowns, memberTownRequest.getAddressId());
 			throw new BadRequestException(ErrorCode.MAXIMUM_MEMBER_TOWN_SIZE);
 		}
 	}

--- a/src/main/java/pie/tomato/tomatomarket/exception/ConflictException.java
+++ b/src/main/java/pie/tomato/tomatomarket/exception/ConflictException.java
@@ -1,0 +1,12 @@
+package pie.tomato.tomatomarket.exception;
+
+public class ConflictException extends TomatoMarketException {
+
+	public ConflictException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+
+	public ConflictException(ErrorCode errorCode, String message) {
+		super(errorCode, message);
+	}
+}

--- a/src/main/java/pie/tomato/tomatomarket/exception/ErrorCode.java
+++ b/src/main/java/pie/tomato/tomatomarket/exception/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
 	ALREADY_ADDRESS(HttpStatus.CONFLICT, "이미 존재하는 동네입니다."),
 	MAXIMUM_MEMBER_TOWN_SIZE(HttpStatus.BAD_REQUEST, "지역 선택은 최대 2개까지 가능합니다."),
 	NOT_FOUND_MEMBER_TOWN(HttpStatus.NOT_FOUND, "등록된 주소를 찾을 수 없습니다."),
+	MINIMUM_MEMBER_TOWN_SIZE(HttpStatus.BAD_REQUEST, "동네는 최소 1개 이상 선택해야 해요. 새로운 동네를 등록한 후 삭제해주세요."),
 
 	// Region
 	NOT_FOUND_REGION(HttpStatus.NOT_FOUND, "주소를 찾을 수 없습니다."),

--- a/src/main/java/pie/tomato/tomatomarket/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/pie/tomato/tomatomarket/exception/handler/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import pie.tomato.tomatomarket.exception.BadRequestException;
+import pie.tomato.tomatomarket.exception.ConflictException;
 import pie.tomato.tomatomarket.exception.ErrorResponse;
 import pie.tomato.tomatomarket.exception.ForbiddenException;
 import pie.tomato.tomatomarket.exception.InternalServerException;
@@ -40,8 +41,14 @@ public class GlobalExceptionHandler {
 	}
 
 	@ExceptionHandler(ForbiddenException.class)
-	public ResponseEntity<ErrorResponse> handleForbiddenException(InternalServerException e) {
-		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+	public ResponseEntity<ErrorResponse> handleForbiddenException(ForbiddenException e) {
+		return ResponseEntity.status(HttpStatus.FORBIDDEN)
 			.body(new ErrorResponse(403, e.getMessage()));
+	}
+
+	@ExceptionHandler(ConflictException.class)
+	public ResponseEntity<ErrorResponse> handleConflictException(ConflictException e) {
+		return ResponseEntity.status(HttpStatus.CONFLICT)
+			.body(new ErrorResponse(409, e.getMessage()));
 	}
 }

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/memberTown/MemberTownRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/memberTown/MemberTownRepository.java
@@ -1,12 +1,20 @@
 package pie.tomato.tomatomarket.infrastructure.persistence.memberTown;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import pie.tomato.tomatomarket.domain.MemberTown;
 
 public interface MemberTownRepository extends JpaRepository<MemberTown, Long> {
 
-	List<MemberTown> findAllByMemberId(Long memberId);
+	Optional<List<MemberTown>> findAllByMemberId(Long memberId);
+
+	@Query("delete from MemberTown memberTown where memberTown.member.id = :memberId and memberTown.region.id = :regionId")
+	@Modifying
+	void deleteByMemberIdAndRegionId(@Param("memberId") Long memberId, @Param("regionId") Long regionId);
 }

--- a/src/main/java/pie/tomato/tomatomarket/presentation/memberTown/MemberTownController.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/memberTown/MemberTownController.java
@@ -52,6 +52,6 @@ public class MemberTownController {
 	public ResponseEntity<Void> deleteMemberTown(@AuthPrincipal Principal principal,
 		@RequestBody DeleteMemberTownRequest deleteMemberTownRequest) {
 		memberTownService.deleteMemberTown(principal, deleteMemberTownRequest);
-		return ResponseEntity.ok().build();
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/pie/tomato/tomatomarket/presentation/memberTown/MemberTownController.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/memberTown/MemberTownController.java
@@ -1,6 +1,7 @@
 package pie.tomato.tomatomarket.presentation.memberTown;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -13,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import pie.tomato.tomatomarket.application.memberTown.MemberTownService;
 import pie.tomato.tomatomarket.presentation.dto.CustomSlice;
 import pie.tomato.tomatomarket.presentation.memberTown.request.AddMemberTownRequest;
+import pie.tomato.tomatomarket.presentation.memberTown.request.DeleteMemberTownRequest;
 import pie.tomato.tomatomarket.presentation.memberTown.request.SelectMemberTownRequest;
 import pie.tomato.tomatomarket.presentation.memberTown.response.MemberTownListResponse;
 import pie.tomato.tomatomarket.presentation.support.AuthPrincipal;
@@ -44,5 +46,12 @@ public class MemberTownController {
 		@RequestParam(required = false, defaultValue = "10") int size,
 		@RequestParam(required = false) Long cursor) {
 		return ResponseEntity.ok().body(memberTownService.findAll(region, size, cursor));
+	}
+
+	@DeleteMapping
+	public ResponseEntity<Void> deleteMemberTown(@AuthPrincipal Principal principal,
+		@RequestBody DeleteMemberTownRequest deleteMemberTownRequest) {
+		memberTownService.deleteMemberTown(principal, deleteMemberTownRequest);
+		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/pie/tomato/tomatomarket/presentation/memberTown/request/DeleteMemberTownRequest.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/memberTown/request/DeleteMemberTownRequest.java
@@ -1,0 +1,15 @@
+package pie.tomato.tomatomarket.presentation.memberTown.request;
+
+import static lombok.AccessLevel.*;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = PROTECTED)
+public class DeleteMemberTownRequest {
+
+	private Long addressId;
+}


### PR DESCRIPTION
## Issues
- #47 

## What is this PR? 👓
지역(동네) 삭제 기능에 대한 PR입니다.

## Key changes 🔑
- 지역(동네) 삭제 기능
- 지역(동네) 삭제 기능 테스트
- 지역(동네) 추가시 기존에 선택한 동네와 새로 추가한 동네 모두 `isSelected = true`가 되서 **새로 추가한 동네를 true**로 **기존 동네를 false**로 변경하게끔 수정


