### PR TITLE
[feat] 상품 상세 조회시 조회수 증가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,8 @@ dependencies {
     implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
     annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}"
 
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/pie/tomato/TomatoMarketApplication.java
+++ b/src/main/java/pie/tomato/TomatoMarketApplication.java
@@ -2,7 +2,9 @@ package pie.tomato;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class TomatoMarketApplication {
 

--- a/src/main/java/pie/tomato/tomatomarket/application/item/ItemService.java
+++ b/src/main/java/pie/tomato/tomatomarket/application/item/ItemService.java
@@ -10,6 +10,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import lombok.RequiredArgsConstructor;
 import pie.tomato.tomatomarket.application.image.ImageService;
+import pie.tomato.tomatomarket.application.redis.ItemViewCountRedisService;
 import pie.tomato.tomatomarket.domain.Category;
 import pie.tomato.tomatomarket.domain.Image;
 import pie.tomato.tomatomarket.domain.Item;
@@ -48,6 +49,7 @@ public class ItemService {
 	private final CategoryRepository categoryRepository;
 	private final WishRepository wishRepository;
 	private final ChatroomRepository chatroomRepository;
+	private final ItemViewCountRedisService itemViewCountRedisService;
 
 	@Transactional
 	public void register(ItemRegisterRequest itemRegisterRequest, MultipartFile thumbnail,
@@ -168,7 +170,8 @@ public class ItemService {
 		}
 	}
 
-	public ItemDetailResponse itemDetails(Long itemId) {
+	public ItemDetailResponse itemDetails(Principal principal, Long itemId) {
+		itemViewCountRedisService.addViewCount(principal.getNickname(), itemId);
 		Item findItem = itemRepository.findById(itemId)
 			.orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_ITEM));
 		boolean isInWishList = wishRepository.existsByItemIdAndMemberId(itemId, findItem.getMember().getId());

--- a/src/main/java/pie/tomato/tomatomarket/application/item/ItemService.java
+++ b/src/main/java/pie/tomato/tomatomarket/application/item/ItemService.java
@@ -171,10 +171,13 @@ public class ItemService {
 	}
 
 	public ItemDetailResponse itemDetails(Principal principal, Long itemId) {
-		itemViewCountRedisService.addViewCount(principal.getNickname(), itemId);
 		Item findItem = itemRepository.findById(itemId)
 			.orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_ITEM));
+
+		itemViewCountRedisService.addViewCount(principal.getNickname(), itemId);
+
 		boolean isInWishList = wishRepository.existsByItemIdAndMemberId(itemId, findItem.getMember().getId());
+
 		List<Image> images = imageRepository.findByItemId(itemId);
 		List<String> imageUrls = images.stream()
 			.map(Image::getImageUrl)
@@ -185,8 +188,10 @@ public class ItemService {
 	public CustomSlice<SalesItemDetailResponse> salesItemDetails(
 		String status, Principal principal, int size, Long cursor) {
 		ItemStatus findStatus = ItemStatus.findStatus(status);
+
 		Slice<SalesItemDetailResponse> responses =
 			itemPaginationRepository.findByMemberIdAndStatus(principal, findStatus, size, cursor);
+
 		List<SalesItemDetailResponse> content = responses.getContent();
 		Long nextCursor = content.isEmpty() ? null : content.get(content.size() - 1).getItemId();
 		return new CustomSlice<>(content, nextCursor, responses.hasNext());

--- a/src/main/java/pie/tomato/tomatomarket/application/redis/ItemViewCountRedisService.java
+++ b/src/main/java/pie/tomato/tomatomarket/application/redis/ItemViewCountRedisService.java
@@ -1,0 +1,65 @@
+package pie.tomato.tomatomarket.application.redis;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import pie.tomato.tomatomarket.infrastructure.persistence.item.ItemRepository;
+
+@Service
+@RequiredArgsConstructor
+public class ItemViewCountRedisService {
+
+	public static final String ITEM_ID_PREFIX = "itemId: ";
+	private static final Pattern ITEM_ID_PATTERN = Pattern.compile("itemId:*");
+
+	private final RedisTemplate<String, String> redisTemplate;
+	private final ItemRepository itemRepository;
+
+	public void addViewCount(String nickname, Long itemId) {
+		String key = ITEM_ID_PREFIX + itemId;
+		String duplicateKey = nickname;
+		ValueOperations<String, String> value = redisTemplate.opsForValue();
+
+		if (isNotFirstView(duplicateKey)) {
+			return;
+		}
+
+		if (value.get(key) != null) {
+			value.increment(key);
+			return;
+		}
+
+		value.set(duplicateKey, String.valueOf(itemId));
+		value.set(key, "1", Duration.ofMinutes(1));
+	}
+
+	private boolean isNotFirstView(String duplicateKey) {
+		return Boolean.TRUE.equals(redisTemplate.hasKey(duplicateKey));
+	}
+
+	@Transactional
+	@Scheduled(cron = "0 0/1 * * * ?")
+	public void deleteViewCountCache() {
+		Set<String> keys = Optional.ofNullable(redisTemplate.keys(ITEM_ID_PATTERN.pattern()))
+			.orElseGet(Collections::emptySet);
+
+		for (String key : keys) {
+			Long itemId = Long.parseLong(key.split(" ")[1]);
+			Long viewCount = Long.valueOf(Optional.ofNullable(redisTemplate.opsForValue().get(key)).orElse("0"));
+			Long originViewCount = itemRepository.findViewCountById(itemId);
+			itemRepository.addViewCountFromRedis(itemId, originViewCount + viewCount);
+			redisTemplate.delete(key);
+			redisTemplate.delete("itemId: " + itemId);
+		}
+	}
+}

--- a/src/main/java/pie/tomato/tomatomarket/domain/Item.java
+++ b/src/main/java/pie/tomato/tomatomarket/domain/Item.java
@@ -99,4 +99,8 @@ public class Item {
 	public void wishCancel() {
 		this.wishCount--;
 	}
+
+	public void changeItemViewCount(Long viewCount) {
+		this.viewCount = viewCount;
+	}
 }

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/config/RedisConfig.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/config/RedisConfig.java
@@ -1,0 +1,34 @@
+package pie.tomato.tomatomarket.infrastructure.config;
+
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableRedisRepositories
+public class RedisConfig {
+
+	private final RedisProperties redisProperties;
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+	}
+
+	@Bean
+	public RedisTemplate<String, String> redisTemplate() {
+		RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(new StringRedisSerializer());
+		redisTemplate.setConnectionFactory(redisConnectionFactory());
+		return redisTemplate;
+	}
+}

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/config/RedisConfig.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/config/RedisConfig.java
@@ -6,14 +6,12 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import lombok.RequiredArgsConstructor;
 
 @Configuration
 @RequiredArgsConstructor
-@EnableRedisRepositories
 public class RedisConfig {
 
 	private final RedisProperties redisProperties;

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/item/ItemRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/item/ItemRepository.java
@@ -5,9 +5,6 @@ import static pie.tomato.tomatomarket.domain.QItem.*;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 
@@ -59,11 +56,4 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
 			return item.status.ne(ItemStatus.SOLD_OUT);
 		}
 	}
-
-	@Query("select item.viewCount from Item item where item.id = :itemId")
-	Long findViewCountById(@Param("itemId") Long itemId);
-
-	@Modifying
-	@Query("update Item item set item.viewCount = :viewCount where item.id = :itemId")
-	void addViewCountFromRedis(@Param("itemId") Long itemId, @Param("viewCount") Long viewCount);
 }

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/item/ItemRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/item/ItemRepository.java
@@ -5,6 +5,9 @@ import static pie.tomato.tomatomarket.domain.QItem.*;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 
@@ -56,4 +59,11 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
 			return item.status.ne(ItemStatus.SOLD_OUT);
 		}
 	}
+
+	@Query("select item.viewCount from Item item where item.id = :itemId")
+	Long findViewCountById(@Param("itemId") Long itemId);
+
+	@Modifying
+	@Query("update Item item set item.viewCount = :viewCount where item.id = :itemId")
+	void addViewCountFromRedis(@Param("itemId") Long itemId, @Param("viewCount") Long viewCount);
 }

--- a/src/main/java/pie/tomato/tomatomarket/presentation/item/ItemController.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/item/ItemController.java
@@ -78,7 +78,8 @@ public class ItemController {
 	}
 
 	@GetMapping("/{itemId}")
-	public ResponseEntity<ItemDetailResponse> itemDetails(@PathVariable Long itemId) {
-		return ResponseEntity.ok().body(itemService.itemDetails(itemId));
+	public ResponseEntity<ItemDetailResponse> itemDetails(@AuthPrincipal Principal principal,
+		@PathVariable Long itemId) {
+		return ResponseEntity.ok().body(itemService.itemDetails(principal, itemId));
 	}
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -3,6 +3,9 @@ spring:
     url: ${db.dev.datasource.url}
     username: ${db.dev.datasource.username}
     password: ${db.dev.datasource.password}
+  redis:
+    host: localhost
+    port: 6379
 
 cloud:
   aws:


### PR DESCRIPTION
## Issues
- #50 

## What is this PR? 👓
상품 상세 조회시 조회수 증가에 대한 PR입니다.

## Key changes 🔑
- 상품 상세조회 요청시 viewCount 증가
- 상품 상세조회 요청시 viewCount 증가 테스트
- 이미 같은 상품을 조회했던 사용자가 또 다시 상품 상세조회 요청을 보냈을 시 뷰카운트 증가는 하지 않습니다.
- 상품의 상세 조회 페이지는 접근이 빈번하게 일어날 것이라고 예상해,
IO 연산을 줄이기 위해 들어온 요청을 캐싱해두고 스케쥴링 시간에 맞춰 RDB에 저장해주는 방식을 구현했습니다.