### PR TITLE
[feat] 채팅방 목록 조회 기능

### DIFF
--- a/src/main/java/pie/tomato/tomatomarket/application/chat/ChatroomService.java
+++ b/src/main/java/pie/tomato/tomatomarket/application/chat/ChatroomService.java
@@ -1,0 +1,32 @@
+package pie.tomato.tomatomarket.application.chat;
+
+import java.util.List;
+
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import pie.tomato.tomatomarket.infrastructure.persistence.chatroom.ChatPaginationRepository;
+import pie.tomato.tomatomarket.presentation.chat.ChatroomListResponse;
+import pie.tomato.tomatomarket.presentation.dto.CustomSlice;
+import pie.tomato.tomatomarket.presentation.support.Principal;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ChatroomService {
+
+	private final ChatPaginationRepository chatPaginationRepository;
+
+	public CustomSlice<ChatroomListResponse> findAll(Principal principal, int size, Long cursor) {
+		Slice<ChatroomListResponse> responses =
+			chatPaginationRepository.findAll(principal.getMemberId(), size, cursor);
+
+		List<ChatroomListResponse> content = responses.getContent();
+
+		Long nextCursor = content.isEmpty() ? null : content.get(content.size() - 1).getChatroomId();
+
+		return new CustomSlice<>(content, nextCursor, responses.hasNext());
+	}
+}

--- a/src/main/java/pie/tomato/tomatomarket/application/chat/ChatroomService.java
+++ b/src/main/java/pie/tomato/tomatomarket/application/chat/ChatroomService.java
@@ -8,7 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import pie.tomato.tomatomarket.infrastructure.persistence.chatroom.ChatPaginationRepository;
-import pie.tomato.tomatomarket.presentation.chat.ChatroomListResponse;
+import pie.tomato.tomatomarket.presentation.chat.response.ChatroomListResponse;
 import pie.tomato.tomatomarket.presentation.dto.CustomSlice;
 import pie.tomato.tomatomarket.presentation.support.Principal;
 

--- a/src/main/java/pie/tomato/tomatomarket/domain/ChatLog.java
+++ b/src/main/java/pie/tomato/tomatomarket/domain/ChatLog.java
@@ -22,12 +22,22 @@ public class ChatLog {
 	@GeneratedValue(strategy = IDENTITY)
 	private Long id;
 	private String message;
-	private String to;
-	private String from;
+	private String seller;
+	private String buyer;
 	private LocalDateTime createdAt;
 	private Long newMessage;
 
 	@ManyToOne(fetch = LAZY)
 	@JoinColumn(name = "chatroom_id")
 	private Chatroom chatroom;
+
+	public ChatLog(String message, String seller, String buyer, LocalDateTime createdAt, Long newMessage,
+		Chatroom chatroom) {
+		this.message = message;
+		this.seller = seller;
+		this.buyer = buyer;
+		this.createdAt = createdAt;
+		this.newMessage = newMessage;
+		this.chatroom = chatroom;
+	}
 }

--- a/src/main/java/pie/tomato/tomatomarket/domain/Chatroom.java
+++ b/src/main/java/pie/tomato/tomatomarket/domain/Chatroom.java
@@ -30,4 +30,10 @@ public class Chatroom {
 	@ManyToOne(fetch = LAZY)
 	@JoinColumn(name = "item_id")
 	private Item item;
+
+	public Chatroom(LocalDateTime createdAt, Member member, Item item) {
+		this.createdAt = createdAt;
+		this.member = member;
+		this.item = item;
+	}
 }

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/chatroom/ChatPaginationRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/chatroom/ChatPaginationRepository.java
@@ -15,7 +15,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
 import pie.tomato.tomatomarket.infrastructure.persistence.util.PaginationUtil;
-import pie.tomato.tomatomarket.presentation.chat.ChatroomListResponse;
+import pie.tomato.tomatomarket.presentation.chat.response.ChatroomListResponse;
 
 @Repository
 @RequiredArgsConstructor

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/chatroom/ChatPaginationRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/chatroom/ChatPaginationRepository.java
@@ -1,0 +1,49 @@
+package pie.tomato.tomatomarket.infrastructure.persistence.chatroom;
+
+import static pie.tomato.tomatomarket.domain.QChatLog.*;
+import static pie.tomato.tomatomarket.domain.QChatroom.*;
+import static pie.tomato.tomatomarket.domain.QItem.*;
+import static pie.tomato.tomatomarket.domain.QMember.*;
+
+import java.util.List;
+
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+import pie.tomato.tomatomarket.infrastructure.persistence.util.PaginationUtil;
+import pie.tomato.tomatomarket.presentation.chat.ChatroomListResponse;
+
+@Repository
+@RequiredArgsConstructor
+public class ChatPaginationRepository {
+
+	private final JPAQueryFactory queryFactory;
+	private final ChatroomRepository chatroomRepository;
+
+	public Slice<ChatroomListResponse> findAll(Long memberId, int size, Long itemId) {
+		List<ChatroomListResponse> responses = queryFactory.select(Projections.fields(ChatroomListResponse.class,
+				chatLog.id.as("chatroomId"),
+				item.thumbnail.as("thumbnailUrl"),
+				member.nickname.as("chatPartnerName"),
+				member.profile.as("chatPartnerProfile"),
+				chatLog.createdAt.as("lastSendTime"),
+				chatLog.message.as("lastSendMessage"),
+				chatLog.newMessage.as("newMessageCount")))
+			.from(chatLog)
+			.innerJoin(chatLog.chatroom, chatroom)
+			.innerJoin(chatroom.item, item)
+			.innerJoin(item.member, member)
+			.where(
+				chatroomRepository.lessThanItemId(itemId),
+				chatroomRepository.equalMemberId(memberId)
+			)
+			.orderBy(chatLog.createdAt.desc())
+			.limit(size + 1)
+			.fetch();
+		return PaginationUtil.checkLastPage(size, responses);
+	}
+}

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/chatroom/ChatroomRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/chatroom/ChatroomRepository.java
@@ -1,9 +1,14 @@
 package pie.tomato.tomatomarket.infrastructure.persistence.chatroom;
 
+import static pie.tomato.tomatomarket.domain.QItem.*;
+import static pie.tomato.tomatomarket.domain.QMember.*;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
 
 import pie.tomato.tomatomarket.domain.Chatroom;
 
@@ -12,4 +17,19 @@ public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
 	@Modifying(clearAutomatically = true, flushAutomatically = true)
 	@Query("delete from Chatroom chatroom where chatroom.item.id = :itemId")
 	void deleteAllByItemId(@Param("itemId") Long itemId);
+
+	default BooleanExpression lessThanItemId(Long itemId) {
+		if (itemId == null) {
+			return null;
+		}
+
+		return item.id.lt(itemId);
+	}
+
+	default BooleanExpression equalMemberId(Long memberId) {
+		if (memberId == null) {
+			return null;
+		}
+		return member.id.eq(memberId);
+	}
 }

--- a/src/main/java/pie/tomato/tomatomarket/presentation/chat/ChatroomController.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/chat/ChatroomController.java
@@ -1,0 +1,28 @@
+package pie.tomato.tomatomarket.presentation.chat;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import pie.tomato.tomatomarket.application.chat.ChatroomService;
+import pie.tomato.tomatomarket.presentation.dto.CustomSlice;
+import pie.tomato.tomatomarket.presentation.support.AuthPrincipal;
+import pie.tomato.tomatomarket.presentation.support.Principal;
+
+@RestController
+@RequestMapping("/api/chats")
+@RequiredArgsConstructor
+public class ChatroomController {
+
+	private final ChatroomService chatroomService;
+
+	@GetMapping
+	public ResponseEntity<CustomSlice<ChatroomListResponse>> findAll(@AuthPrincipal Principal principal,
+		@RequestParam(required = false, defaultValue = "10") int size,
+		@RequestParam(required = false) Long cursor) {
+		return ResponseEntity.ok(chatroomService.findAll(principal, size, cursor));
+	}
+}

--- a/src/main/java/pie/tomato/tomatomarket/presentation/chat/ChatroomController.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/chat/ChatroomController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 import pie.tomato.tomatomarket.application.chat.ChatroomService;
+import pie.tomato.tomatomarket.presentation.chat.response.ChatroomListResponse;
 import pie.tomato.tomatomarket.presentation.dto.CustomSlice;
 import pie.tomato.tomatomarket.presentation.support.AuthPrincipal;
 import pie.tomato.tomatomarket.presentation.support.Principal;

--- a/src/main/java/pie/tomato/tomatomarket/presentation/chat/ChatroomListResponse.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/chat/ChatroomListResponse.java
@@ -1,0 +1,17 @@
+package pie.tomato.tomatomarket.presentation.chat;
+
+import java.time.LocalDateTime;
+
+import lombok.Getter;
+
+@Getter
+public class ChatroomListResponse {
+
+	private Long chatroomId;
+	private String thumbnailUrl;
+	private String chatPartnerName;
+	private String chatPartnerProfile;
+	private LocalDateTime lastSendTime;
+	private String lastSendMessage;
+	private Long newMessageCount;
+}

--- a/src/main/java/pie/tomato/tomatomarket/presentation/chat/response/ChatroomListResponse.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/chat/response/ChatroomListResponse.java
@@ -1,4 +1,4 @@
-package pie.tomato.tomatomarket.presentation.chat;
+package pie.tomato.tomatomarket.presentation.chat.response;
 
 import java.time.LocalDateTime;
 

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -143,7 +143,7 @@ CREATE TABLE IF NOT EXISTS `mydb`.`wish`
 -- -----------------------------------------------------
 -- Table `mydb`.`chat_room`
 -- -----------------------------------------------------
-CREATE TABLE IF NOT EXISTS `mydb`.`chat_room`
+CREATE TABLE IF NOT EXISTS `mydb`.`chatroom`
 (
     `id`         BIGINT    NOT NULL AUTO_INCREMENT,
     `created_at` TIMESTAMP NOT NULL,
@@ -171,18 +171,18 @@ CREATE TABLE IF NOT EXISTS `mydb`.`chat_room`
 -- -----------------------------------------------------
 CREATE TABLE IF NOT EXISTS `mydb`.`chat_log`
 (
-    `id`           BIGINT       NOT NULL AUTO_INCREMENT,
-    `message`      VARCHAR(512) NOT NULL,
-    `to`           VARCHAR(45)  NOT NULL,
-    `form`         VARCHAR(45)  NOT NULL,
-    `created_at`   TIMESTAMP    NOT NULL,
-    `new_massage`  BIGINT       NOT NULL,
-    `chat_room_id` BIGINT       NOT NULL,
+    `id`          BIGINT       NOT NULL AUTO_INCREMENT,
+    `message`     VARCHAR(512) NOT NULL,
+    `seller`      VARCHAR(45)  NOT NULL,
+    `buyer`       VARCHAR(45)  NOT NULL,
+    `created_at`  TIMESTAMP    NOT NULL,
+    `new_massage` BIGINT       NOT NULL,
+    chatroom_id   BIGINT       NOT NULL,
     PRIMARY KEY (`id`),
-    INDEX `fk_chat_log_chat_room2_idx` (`chat_room_id` ASC) VISIBLE,
+    INDEX `fk_chat_log_chat_room2_idx` (chatroom_id ASC) VISIBLE,
     CONSTRAINT `fk_chat_log_chat_room2`
-        FOREIGN KEY (`chat_room_id`)
-            REFERENCES `mydb`.`chat_room` (`id`)
+        FOREIGN KEY (chatroom_id)
+            REFERENCES `mydb`.`chatroom` (`id`)
             ON DELETE NO ACTION
             ON UPDATE NO ACTION
 )

--- a/src/test/java/pie/tomato/tomatomarket/application/ChatroomServiceTest.java
+++ b/src/test/java/pie/tomato/tomatomarket/application/ChatroomServiceTest.java
@@ -1,0 +1,80 @@
+package pie.tomato.tomatomarket.application;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import pie.tomato.tomatomarket.application.chat.ChatroomService;
+import pie.tomato.tomatomarket.domain.Category;
+import pie.tomato.tomatomarket.domain.ChatLog;
+import pie.tomato.tomatomarket.domain.Chatroom;
+import pie.tomato.tomatomarket.domain.Item;
+import pie.tomato.tomatomarket.domain.ItemStatus;
+import pie.tomato.tomatomarket.domain.Member;
+import pie.tomato.tomatomarket.presentation.chat.ChatroomListResponse;
+import pie.tomato.tomatomarket.presentation.dto.CustomSlice;
+import pie.tomato.tomatomarket.presentation.support.Principal;
+import pie.tomato.tomatomarket.support.SupportRepository;
+
+@Transactional
+@SpringBootTest
+class ChatroomServiceTest {
+
+	@Autowired
+	private SupportRepository supportRepository;
+	@Autowired
+	private ChatroomService chatroomService;
+
+	@DisplayName("채팅방 목록을 불러오는데 성공한다.")
+	@Test
+	void findAllChatroom() {
+		// given
+		Member member = setupMember("파이", "123@123", "profile");
+		Principal principal = setPrincipal(member);
+		Category category = setupCategory();
+		Item item = setupItem(member, category);
+		Chatroom chatroom = new Chatroom(LocalDateTime.now().minusSeconds(5), member, item);
+		supportRepository.save(chatroom);
+		supportRepository.save(new ChatLog("얼마에요", "브루니", "파이", LocalDateTime.now(), 0L, chatroom));
+
+		// when
+		CustomSlice<ChatroomListResponse> response = chatroomService.findAll(principal, 10, null);
+
+		// then
+		assertThat(response.getContents().get(0)).hasFieldOrProperty("chatroomId")
+			.hasFieldOrProperty("thumbnailUrl")
+			.hasFieldOrProperty("chatPartnerName")
+			.hasFieldOrProperty("chatPartnerProfile")
+			.hasFieldOrProperty("lastSendTime")
+			.hasFieldOrProperty("lastSendMessage")
+			.hasFieldOrProperty("newMessageCount");
+	}
+
+	Principal setPrincipal(Member member) {
+		Principal principal = Principal.builder()
+			.nickname(member.getNickname())
+			.email(member.getEmail())
+			.memberId(member.getId())
+			.build();
+		return principal;
+	}
+
+	Member setupMember(String nickname, String email, String profile) {
+		return supportRepository.save(new Member(nickname, email, profile));
+	}
+
+	Category setupCategory() {
+		return supportRepository.save(new Category("잡화", "categoryImage"));
+	}
+
+	Item setupItem(Member member, Category category) {
+		return supportRepository.save(new Item("1번", "내용1", 3000L, "thumbnail", ItemStatus.ON_SALE,
+			"역삼1동", 0L, 0L, 0L, LocalDateTime.now(), member, category));
+	}
+}

--- a/src/test/java/pie/tomato/tomatomarket/application/ChatroomServiceTest.java
+++ b/src/test/java/pie/tomato/tomatomarket/application/ChatroomServiceTest.java
@@ -17,7 +17,7 @@ import pie.tomato.tomatomarket.domain.Chatroom;
 import pie.tomato.tomatomarket.domain.Item;
 import pie.tomato.tomatomarket.domain.ItemStatus;
 import pie.tomato.tomatomarket.domain.Member;
-import pie.tomato.tomatomarket.presentation.chat.ChatroomListResponse;
+import pie.tomato.tomatomarket.presentation.chat.response.ChatroomListResponse;
 import pie.tomato.tomatomarket.presentation.dto.CustomSlice;
 import pie.tomato.tomatomarket.presentation.support.Principal;
 import pie.tomato.tomatomarket.support.SupportRepository;


### PR DESCRIPTION
## Issues
- #56 

## What is this PR? 👓
- 채팅방 목록 조회에 대한 PR입니다.

## Key changes 🔑
- 채팅방 목록 조회
- 채팅방 목록 조회 테스트

## 📖 공부하면서 배웠던 것
### 📌 VISIBLE? INVISIBLE?

```scheme
PRIMARY KEY (`id`),
    INDEX `fk_chat_log_chat_room2_idx` (chatroom_id ASC) VISIBLE,
```

쉽게 설명하자면 VISIBLE은 인덱스가 켜져 있는 상태이고, INVISIBLE은 껏다 켰다 할 수 있는 상태이다. 그렇다면 왜 인덱스를 껏다 켰다 하는 것일까? 찾아본 바로는 성능을 테스트 하기 위함이다. DB 테이블에 데이터가 많을 때, 인덱스가 없으면 조회하는데 오래 걸리는 경우가 있고 인덱스가 있으면 오래 안걸리는 경우가 있는데 그때 둘의 차이를 비교하기 위해 껏다 켤 수 있는 INVISIBLE 기능을 사용한다. 인덱스의 default는 VISIBLE이기 때문에 따로 설정하지 않아도 된다.

### 📌 ON DELETE NO ACTION, ON UPDATE NO ACTION

```scheme
FOREIGN KEY (chatroom_id)
     REFERENCES `mydb`.`chatroom` (`id`)
     ON DELETE NO ACTION
     ON UPDATE NO ACTION
```

✔️ **ON DELETE NO ACTION**

`ON DELETE NO ACTION`을 작성하면 연관된 테이블의 행이 삭제될 때 참조하는 행이 남아있게 되면 삭제를 하지 않는 옵션이다.

✔️ **ON UPDATE NO ACTION**

`ON UPDATE NO ACTION`도 마찬가지로 테이블을 변경하려 할 때 참조하는 행이 남아있게 되면 변경이 되지 않는 옵션이다. 예를 들어 item 클래스가 member 클래스의 id를 참조하고 있는데 member클래스의 id를 임의로 변경하려 한다면 참조중인 item 클래스도 그 영향을 미치기때문에 데이터의 정합성을 위해 사용한다.