### PR TITLE
[feat] 안읽은 채팅 메세지 개수 확인 기능

### DIFF
--- a/src/main/java/pie/tomato/tomatomarket/application/chat/ChatLogService.java
+++ b/src/main/java/pie/tomato/tomatomarket/application/chat/ChatLogService.java
@@ -47,6 +47,7 @@ public class ChatLogService {
 		}
 	}
 
+	@Transactional
 	public ChatMessageResponse getMessages(Principal principal, Long chatroomId,
 		int size, Long messageIndex) {
 		final DeferredResult<List<String>> deferredResult =
@@ -64,6 +65,8 @@ public class ChatLogService {
 
 		Chatroom chatroom = chatroomRepository.findById(chatroomId)
 			.orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_CHATROOM));
+
+		chatLogRepository.changeToReadState(chatroomId, messageIndex);
 
 		return new ChatMessageResponse(
 			getPartnerName(principal.getMemberId(), chatroom),

--- a/src/main/java/pie/tomato/tomatomarket/application/chat/ChatroomService.java
+++ b/src/main/java/pie/tomato/tomatomarket/application/chat/ChatroomService.java
@@ -37,6 +37,11 @@ public class ChatroomService {
 
 		List<ChatroomListResponse> content = responses.getContent();
 
+		for (ChatroomListResponse chatroomListResponse : content) {
+			Long messageCount = chatroomRepository.getNewMessageCount(chatroomListResponse.getChatroomId());
+			chatroomListResponse.assignNewMessageCount(messageCount);
+		}
+
 		Long nextCursor = content.isEmpty() ? null : content.get(content.size() - 1).getChatroomId();
 
 		return new CustomSlice<>(content, nextCursor, responses.hasNext());

--- a/src/main/java/pie/tomato/tomatomarket/domain/ChatLog.java
+++ b/src/main/java/pie/tomato/tomatomarket/domain/ChatLog.java
@@ -22,6 +22,8 @@ import pie.tomato.tomatomarket.presentation.support.Principal;
 @NoArgsConstructor(access = PROTECTED)
 public class ChatLog {
 
+	private static final Long UNREAD_MESSAGE_COUNT = 1L;
+
 	@Id
 	@GeneratedValue(strategy = IDENTITY)
 	private Long id;
@@ -47,6 +49,7 @@ public class ChatLog {
 
 	public static ChatLog of(PostMessageRequest request, Principal principal, String receiver, Chatroom chatroom) {
 		return new ChatLog(
-			request.getMessage(), principal.getNickname(), receiver, LocalDateTime.now(), 1L, chatroom);
+			request.getMessage(), principal.getNickname(), receiver, LocalDateTime.now(), UNREAD_MESSAGE_COUNT,
+			chatroom);
 	}
 }

--- a/src/main/java/pie/tomato/tomatomarket/domain/ChatLog.java
+++ b/src/main/java/pie/tomato/tomatomarket/domain/ChatLog.java
@@ -47,6 +47,6 @@ public class ChatLog {
 
 	public static ChatLog of(PostMessageRequest request, Principal principal, String receiver, Chatroom chatroom) {
 		return new ChatLog(
-			request.getMessage(), principal.getNickname(), receiver, LocalDateTime.now(), 0L, chatroom);
+			request.getMessage(), principal.getNickname(), receiver, LocalDateTime.now(), 1L, chatroom);
 	}
 }

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/chat/ChatLogRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/chat/ChatLogRepository.java
@@ -3,12 +3,20 @@ package pie.tomato.tomatomarket.infrastructure.persistence.chat;
 import static pie.tomato.tomatomarket.domain.QChatLog.*;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 
 import pie.tomato.tomatomarket.domain.ChatLog;
 
 public interface ChatLogRepository extends JpaRepository<ChatLog, Long> {
+
+	@Modifying
+	@Query("update ChatLog chatLog set chatLog.newMessage = 0 "
+		+ "where chatLog.chatroom.id = :chatroomId and chatLog.id >= :messageIndex")
+	void changeToReadState(@Param("chatroomId") Long chatroomId, @Param("messageIndex") Long messageIndex);
 
 	default BooleanExpression lessThanMessageIndex(Long messageIndex) {
 		if (messageIndex == null) {

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/chat/ChatPaginationRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/chat/ChatPaginationRepository.java
@@ -24,21 +24,20 @@ public class ChatPaginationRepository {
 	private final JPAQueryFactory queryFactory;
 	private final ChatroomRepository chatroomRepository;
 
-	public Slice<ChatroomListResponse> findAll(Long memberId, int size, Long itemId) {
+	public Slice<ChatroomListResponse> findAll(Long memberId, int size, Long chatroomId) {
 		List<ChatroomListResponse> responses = queryFactory.select(Projections.fields(ChatroomListResponse.class,
-				chatLog.id.as("chatroomId"),
+				chatLog.chatroom.id.as("chatroomId"),
 				item.thumbnail.as("thumbnailUrl"),
 				member.nickname.as("chatPartnerName"),
 				member.profile.as("chatPartnerProfile"),
 				chatLog.createdAt.as("lastSendTime"),
-				chatLog.message.as("lastSendMessage"),
-				chatLog.newMessage.as("newMessageCount")))
+				chatLog.message.as("lastSendMessage")))
 			.from(chatLog)
 			.innerJoin(chatLog.chatroom, chatroom)
 			.innerJoin(chatroom.item, item)
 			.innerJoin(item.member, member)
 			.where(
-				chatroomRepository.lessThanItemId(itemId),
+				chatroomRepository.lessThanChatroomId(chatroomId),
 				chatroomRepository.equalMemberId(memberId)
 			)
 			.orderBy(chatLog.createdAt.desc())

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/chat/ChatroomRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/chat/ChatroomRepository.java
@@ -1,7 +1,6 @@
 package pie.tomato.tomatomarket.infrastructure.persistence.chat;
 
-import static pie.tomato.tomatomarket.domain.QItem.*;
-import static pie.tomato.tomatomarket.domain.QMember.*;
+import static pie.tomato.tomatomarket.domain.QChatroom.*;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -18,18 +17,21 @@ public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
 	@Query("delete from Chatroom chatroom where chatroom.item.id = :itemId")
 	void deleteAllByItemId(@Param("itemId") Long itemId);
 
-	default BooleanExpression lessThanItemId(Long itemId) {
-		if (itemId == null) {
+	@Query("SELECT COUNT(1) FROM ChatLog chatLog WHERE chatLog.chatroom.id = :chatroomId AND chatLog.newMessage = 1")
+	Long getNewMessageCount(@Param("chatroomId") Long chatroomId);
+
+	default BooleanExpression lessThanChatroomId(Long chatroomId) {
+		if (chatroomId == null) {
 			return null;
 		}
 
-		return item.id.lt(itemId);
+		return chatroom.id.lt(chatroomId);
 	}
 
 	default BooleanExpression equalMemberId(Long memberId) {
 		if (memberId == null) {
 			return null;
 		}
-		return member.id.eq(memberId);
+		return chatroom.buyer.id.eq(memberId).or(chatroom.seller.id.eq(memberId));
 	}
 }

--- a/src/main/java/pie/tomato/tomatomarket/presentation/chat/response/ChatroomListResponse.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/chat/response/ChatroomListResponse.java
@@ -14,4 +14,8 @@ public class ChatroomListResponse {
 	private LocalDateTime lastSendTime;
 	private String lastSendMessage;
 	private Long newMessageCount;
+
+	public void assignNewMessageCount(Long newMessageCount) {
+		this.newMessageCount = newMessageCount;
+	}
 }

--- a/src/test/java/pie/tomato/tomatomarket/application/ChatLogServiceTest.java
+++ b/src/test/java/pie/tomato/tomatomarket/application/ChatLogServiceTest.java
@@ -71,8 +71,14 @@ class ChatLogServiceTest {
 		Item item = setupItem(seller, category);
 		Chatroom chatroom = new Chatroom(seller, buyer, item);
 		supportRepository.save(chatroom);
-		ChatLog chatLog = ChatLog.of(new PostMessageRequest("안녕하세요"), principalBuyer, "파이", chatroom);
-		supportRepository.save(chatLog);
+		ChatLog chat1 = ChatLog.of(new PostMessageRequest("안녕하세요"), principalBuyer, "파이", chatroom);
+		ChatLog chat2 = ChatLog.of(new PostMessageRequest("안녕하세요1"), principalBuyer, "파이", chatroom);
+		ChatLog chat3 = ChatLog.of(new PostMessageRequest("안녕하세요2"), principalBuyer, "파이", chatroom);
+		ChatLog chat4 = ChatLog.of(new PostMessageRequest("안녕하세요3"), principalBuyer, "파이", chatroom);
+		setupChatLog(chat1);
+		setupChatLog(chat2);
+		setupChatLog(chat3);
+		setupChatLog(chat4);
 
 		// when
 		ChatMessageResponse messages = chatLogService.getMessages(principalSeller, chatroom.getId(), 20, 0L);
@@ -80,7 +86,7 @@ class ChatLogServiceTest {
 		// then
 		assertAll(
 			() -> assertThat(messages.getChatPartnerName()).isEqualTo(buyer.getNickname()),
-			() -> assertThat(messages.getChat().size()).isEqualTo(1),
+			() -> assertThat(messages.getChat().size()).isEqualTo(4),
 			() -> assertThat(messages.getItem().getTitle()).isEqualTo(item.getTitle())
 		);
 	}
@@ -105,5 +111,9 @@ class ChatLogServiceTest {
 	Item setupItem(Member member, Category category) {
 		return supportRepository.save(new Item("1번", "내용1", 3000L, "thumbnail", ItemStatus.ON_SALE,
 			"역삼1동", 0L, 0L, 0L, LocalDateTime.now(), member, category));
+	}
+
+	void setupChatLog(ChatLog chatLog) {
+		supportRepository.save(chatLog);
 	}
 }

--- a/src/test/java/pie/tomato/tomatomarket/application/ChatroomServiceTest.java
+++ b/src/test/java/pie/tomato/tomatomarket/application/ChatroomServiceTest.java
@@ -40,7 +40,7 @@ class ChatroomServiceTest {
 		// given
 		Member seller = setupMember("파이", "123@123", "profile");
 		Member buyer = setupMember("브루니", "2121@1211", "profile2");
-		Principal principal = setPrincipal(seller);
+		Principal principalSeller = setPrincipal(seller);
 		Principal principalBuyer = setPrincipal(buyer);
 		Category category = setupCategory();
 		Item item = setupItem(seller, category);
@@ -50,7 +50,7 @@ class ChatroomServiceTest {
 		supportRepository.save(ChatLog.of(new PostMessageRequest("얼마에요"), principalBuyer, "파이", chatroom));
 
 		// when
-		CustomSlice<ChatroomListResponse> response = chatroomService.findAll(principal, 10, null);
+		CustomSlice<ChatroomListResponse> response = chatroomService.findAll(principalSeller, 10, null);
 
 		// then
 		assertThat(response.getContents().get(0)).hasFieldOrProperty("chatroomId")
@@ -84,6 +84,31 @@ class ChatroomServiceTest {
 				.hasFieldOrProperty("item")
 				.hasFieldOrProperty("createdAt")
 		);
+	}
+
+	@DisplayName("안읽은 채팅 메세지 개수를 확인한다.")
+	@Test
+	void newMessageCount() {
+		// given
+		Member seller = setupMember("파이", "123@123", "profile");
+		Member buyer = setupMember("브루니", "2121@1211", "profile2");
+		Principal principalSeller = setPrincipal(seller);
+		Principal principalBuyer = setPrincipal(buyer);
+		Category category = setupCategory();
+		Item item = setupItem(seller, category);
+		Chatroom chatroom = new Chatroom(seller, buyer, item);
+		supportRepository.save(chatroom);
+
+		supportRepository.save(ChatLog.of(new PostMessageRequest("안녕하세요"), principalBuyer, "파이", chatroom));
+		supportRepository.save(ChatLog.of(new PostMessageRequest("물건"), principalBuyer, "파이", chatroom));
+		supportRepository.save(ChatLog.of(new PostMessageRequest("팔렸나요"), principalBuyer, "파이", chatroom));
+		supportRepository.save(ChatLog.of(new PostMessageRequest("얼마에요"), principalBuyer, "파이", chatroom));
+
+		// when
+		CustomSlice<ChatroomListResponse> all = chatroomService.findAll(principalSeller, 10, null);
+
+		// then
+		assertThat(all.getContents().get(0).getNewMessageCount()).isEqualTo(4);
 	}
 
 	Principal setPrincipal(Member member) {

--- a/src/test/java/pie/tomato/tomatomarket/application/ChatroomServiceTest.java
+++ b/src/test/java/pie/tomato/tomatomarket/application/ChatroomServiceTest.java
@@ -88,7 +88,7 @@ class ChatroomServiceTest {
 
 	@DisplayName("안읽은 채팅 메세지 개수를 확인한다.")
 	@Test
-	void newMessageCount() {
+	void countUnreadMessage() {
 		// given
 		Member seller = setupMember("파이", "123@123", "profile");
 		Member buyer = setupMember("브루니", "2121@1211", "profile2");


### PR DESCRIPTION
## Issues
- #66 

## What is this PR? 👓
읽지 않은 채팅방의 메세지 개수를 확인하는 기능에 대한 PR입니다.

## Key changes 🔑
- 이전 PR에 깜빡한 테스트 코드 수정
- 안읽은 채팅 메세지 개수 확인 기능
- 안읽은 채팅 메세지 개수 확인 기능 테스트
