### PR TITLE
[refactor] 채팅방 목록 조회 기능 수정

### DIFF
--- a/src/main/java/pie/tomato/tomatomarket/application/chat/ChatroomService.java
+++ b/src/main/java/pie/tomato/tomatomarket/application/chat/ChatroomService.java
@@ -50,8 +50,9 @@ public class ChatroomService {
 	}
 
 	private void assignResponseInfo(Principal principal, ChatroomListResponse chatroomListResponse) {
-		ChatLog findChatLog = chatLogRepository.findFirstByChatroomId(chatroomListResponse.getChatroomId());
-		chatroomListResponse.assignLastMessageInfo(findChatLog);
+		ChatLog acquiredChatLog =
+			chatLogRepository.findTopByChatroomIdOrderByChatroomIdDesc(chatroomListResponse.getChatroomId());
+		chatroomListResponse.assignLastMessageInfo(acquiredChatLog);
 
 		Long messageCount = chatroomRepository.getNewMessageCount(chatroomListResponse.getChatroomId());
 		chatroomListResponse.assignNewMessageCount(messageCount);

--- a/src/main/java/pie/tomato/tomatomarket/application/chat/ChatroomService.java
+++ b/src/main/java/pie/tomato/tomatomarket/application/chat/ChatroomService.java
@@ -7,11 +7,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import pie.tomato.tomatomarket.domain.ChatLog;
 import pie.tomato.tomatomarket.domain.Chatroom;
 import pie.tomato.tomatomarket.domain.Item;
 import pie.tomato.tomatomarket.domain.Member;
 import pie.tomato.tomatomarket.exception.ErrorCode;
 import pie.tomato.tomatomarket.exception.NotFoundException;
+import pie.tomato.tomatomarket.infrastructure.persistence.chat.ChatLogRepository;
 import pie.tomato.tomatomarket.infrastructure.persistence.chat.ChatPaginationRepository;
 import pie.tomato.tomatomarket.infrastructure.persistence.chat.ChatroomRepository;
 import pie.tomato.tomatomarket.infrastructure.persistence.item.ItemRepository;
@@ -28,6 +30,7 @@ public class ChatroomService {
 
 	private final ChatPaginationRepository chatPaginationRepository;
 	private final ChatroomRepository chatroomRepository;
+	private final ChatLogRepository chatLogRepository;
 	private final MemberRepository memberRepository;
 	private final ItemRepository itemRepository;
 
@@ -38,13 +41,28 @@ public class ChatroomService {
 		List<ChatroomListResponse> content = responses.getContent();
 
 		for (ChatroomListResponse chatroomListResponse : content) {
-			Long messageCount = chatroomRepository.getNewMessageCount(chatroomListResponse.getChatroomId());
-			chatroomListResponse.assignNewMessageCount(messageCount);
+			assignResponseInfo(principal, chatroomListResponse);
 		}
 
 		Long nextCursor = content.isEmpty() ? null : content.get(content.size() - 1).getChatroomId();
 
 		return new CustomSlice<>(content, nextCursor, responses.hasNext());
+	}
+
+	private void assignResponseInfo(Principal principal, ChatroomListResponse chatroomListResponse) {
+		ChatLog findChatLog = chatLogRepository.findFirstByChatroomId(chatroomListResponse.getChatroomId());
+		chatroomListResponse.assignLastMessageInfo(findChatLog);
+
+		Long messageCount = chatroomRepository.getNewMessageCount(chatroomListResponse.getChatroomId());
+		chatroomListResponse.assignNewMessageCount(messageCount);
+
+		Chatroom chatroom = findChatroom(chatroomListResponse.getChatroomId());
+		chatroomListResponse.assignPartnerInfo(chatroom, principal);
+	}
+
+	private Chatroom findChatroom(Long chatroomId) {
+		return chatroomRepository.findById(chatroomId)
+			.orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_CHATROOM));
 	}
 
 	@Transactional

--- a/src/main/java/pie/tomato/tomatomarket/domain/Chatroom.java
+++ b/src/main/java/pie/tomato/tomatomarket/domain/Chatroom.java
@@ -50,4 +50,8 @@ public class Chatroom {
 		}
 		return buyer.getNickname();
 	}
+
+	public boolean isSeller(Long memberId) {
+		return seller.getId() == memberId;
+	}
 }

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/chat/ChatLogRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/chat/ChatLogRepository.java
@@ -18,9 +18,7 @@ public interface ChatLogRepository extends JpaRepository<ChatLog, Long> {
 		+ "where chatLog.chatroom.id = :chatroomId and chatLog.id >= :messageIndex")
 	void changeToReadState(@Param("chatroomId") Long chatroomId, @Param("messageIndex") Long messageIndex);
 
-	@Query(value = "SELECT * FROM chat_log chatLog "
-		+ "WHERE chatLog.chatroom_id = :chatroomId ORDER BY chatLog.id DESC LIMIT 1", nativeQuery = true)
-	ChatLog findFirstByChatroomId(@Param("chatroomId") Long chatroomId);
+	ChatLog findTopByChatroomIdOrderByChatroomIdDesc(Long chatroomId);
 
 	default BooleanExpression lessThanMessageIndex(Long messageIndex) {
 		if (messageIndex == null) {

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/chat/ChatLogRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/chat/ChatLogRepository.java
@@ -18,6 +18,10 @@ public interface ChatLogRepository extends JpaRepository<ChatLog, Long> {
 		+ "where chatLog.chatroom.id = :chatroomId and chatLog.id >= :messageIndex")
 	void changeToReadState(@Param("chatroomId") Long chatroomId, @Param("messageIndex") Long messageIndex);
 
+	@Query(value = "SELECT * FROM chat_log chatLog "
+		+ "WHERE chatLog.chatroom_id = :chatroomId ORDER BY chatLog.id DESC LIMIT 1", nativeQuery = true)
+	ChatLog findFirstByChatroomId(@Param("chatroomId") Long chatroomId);
+
 	default BooleanExpression lessThanMessageIndex(Long messageIndex) {
 		if (messageIndex == null) {
 			return null;

--- a/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/chat/ChatPaginationRepository.java
+++ b/src/main/java/pie/tomato/tomatomarket/infrastructure/persistence/chat/ChatPaginationRepository.java
@@ -1,9 +1,7 @@
 package pie.tomato.tomatomarket.infrastructure.persistence.chat;
 
-import static pie.tomato.tomatomarket.domain.QChatLog.*;
 import static pie.tomato.tomatomarket.domain.QChatroom.*;
 import static pie.tomato.tomatomarket.domain.QItem.*;
-import static pie.tomato.tomatomarket.domain.QMember.*;
 
 import java.util.List;
 
@@ -26,21 +24,14 @@ public class ChatPaginationRepository {
 
 	public Slice<ChatroomListResponse> findAll(Long memberId, int size, Long chatroomId) {
 		List<ChatroomListResponse> responses = queryFactory.select(Projections.fields(ChatroomListResponse.class,
-				chatLog.chatroom.id.as("chatroomId"),
-				item.thumbnail.as("thumbnailUrl"),
-				member.nickname.as("chatPartnerName"),
-				member.profile.as("chatPartnerProfile"),
-				chatLog.createdAt.as("lastSendTime"),
-				chatLog.message.as("lastSendMessage")))
-			.from(chatLog)
-			.innerJoin(chatLog.chatroom, chatroom)
+				chatroom.id.as("chatroomId"),
+				item.thumbnail.as("thumbnailUrl")))
+			.from(chatroom)
 			.innerJoin(chatroom.item, item)
-			.innerJoin(item.member, member)
 			.where(
 				chatroomRepository.lessThanChatroomId(chatroomId),
 				chatroomRepository.equalMemberId(memberId)
 			)
-			.orderBy(chatLog.createdAt.desc())
 			.limit(size + 1)
 			.fetch();
 		return PaginationUtil.checkLastPage(size, responses);

--- a/src/main/java/pie/tomato/tomatomarket/presentation/chat/response/ChatroomListResponse.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/chat/response/ChatroomListResponse.java
@@ -3,6 +3,9 @@ package pie.tomato.tomatomarket.presentation.chat.response;
 import java.time.LocalDateTime;
 
 import lombok.Getter;
+import pie.tomato.tomatomarket.domain.ChatLog;
+import pie.tomato.tomatomarket.domain.Chatroom;
+import pie.tomato.tomatomarket.presentation.support.Principal;
 
 @Getter
 public class ChatroomListResponse {
@@ -17,5 +20,20 @@ public class ChatroomListResponse {
 
 	public void assignNewMessageCount(Long newMessageCount) {
 		this.newMessageCount = newMessageCount;
+	}
+
+	public void assignLastMessageInfo(ChatLog chatLog) {
+		this.lastSendTime = chatLog.getCreatedAt();
+		this.lastSendMessage = chatLog.getMessage();
+	}
+
+	public void assignPartnerInfo(Chatroom chatroom, Principal principal) {
+		if (chatroom.getSeller().getId() == principal.getMemberId()) {
+			this.chatPartnerName = chatroom.getBuyer().getNickname();
+			this.chatPartnerProfile = chatroom.getBuyer().getProfile();
+		} else {
+			this.chatPartnerName = chatroom.getSeller().getNickname();
+			this.chatPartnerProfile = chatroom.getSeller().getProfile();
+		}
 	}
 }

--- a/src/main/java/pie/tomato/tomatomarket/presentation/chat/response/ChatroomListResponse.java
+++ b/src/main/java/pie/tomato/tomatomarket/presentation/chat/response/ChatroomListResponse.java
@@ -28,7 +28,7 @@ public class ChatroomListResponse {
 	}
 
 	public void assignPartnerInfo(Chatroom chatroom, Principal principal) {
-		if (chatroom.getSeller().getId() == principal.getMemberId()) {
+		if (chatroom.isSeller(principal.getMemberId())) {
 			this.chatPartnerName = chatroom.getBuyer().getNickname();
 			this.chatPartnerProfile = chatroom.getBuyer().getProfile();
 		} else {

--- a/src/test/java/pie/tomato/tomatomarket/application/ChatroomServiceTest.java
+++ b/src/test/java/pie/tomato/tomatomarket/application/ChatroomServiceTest.java
@@ -53,13 +53,16 @@ class ChatroomServiceTest {
 		CustomSlice<ChatroomListResponse> response = chatroomService.findAll(principalSeller, 10, null);
 
 		// then
-		assertThat(response.getContents().get(0)).hasFieldOrProperty("chatroomId")
-			.hasFieldOrProperty("thumbnailUrl")
-			.hasFieldOrProperty("chatPartnerName")
-			.hasFieldOrProperty("chatPartnerProfile")
-			.hasFieldOrProperty("lastSendTime")
-			.hasFieldOrProperty("lastSendMessage")
-			.hasFieldOrProperty("newMessageCount");
+		assertAll(
+			() -> assertThat(response.getContents().get(0)).hasFieldOrProperty("chatroomId")
+				.hasFieldOrProperty("thumbnailUrl")
+				.hasFieldOrProperty("chatPartnerName")
+				.hasFieldOrProperty("chatPartnerProfile")
+				.hasFieldOrProperty("lastSendTime")
+				.hasFieldOrProperty("lastSendMessage")
+				.hasFieldOrProperty("newMessageCount"),
+			() -> assertThat(response.getContents().get(0).getChatPartnerName()).isEqualTo("브루니")
+		);
 	}
 
 	@DisplayName("채팅방 생성에 성공한다.")


### PR DESCRIPTION
## Issues
- #68 

## What is this PR? 👓
채팅방 목록 조회 시 데이터를 잘못 가져와 코드 수정에 대한 PR입니다.

## Key changes 🔑
- `chatroomId`가 아닌 `chatLogId`를 가져오는것을 수정
- 채팅하는 상대방에 대한 정보를 가져오지 못하는 것을 수정
- `chatroomId`에 해당하는 `chatLog`의 마지막 메세지와 그 시간을 가져오지 못하는 것을 수정
